### PR TITLE
Feat gates

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -13,7 +13,8 @@ offers a good explanation of Grover's. This guide does not attempt to
 explain either of these subjects in detail.
 
 The complete code that is built from following this guide is available
-at the end.
+at the end. Or, the code can be found in `examples/grovers.rs`, and ran
+from the root directory with `cargo run --example grovers`.
 
 ---
 
@@ -158,9 +159,9 @@ This completes the construction and measurement of a three qubit
 Grover's circuit. Other functions (which include examples in their
 documentation) can add gates in other ways.
 
-The following is the completed code. This can be copied directly to your
-`main.rs` and ran with `cargo run`. Make sure that quantr is added as a
-dependency.
+The following is the completed code. This can also be found in
+`examples/grovers.rs`, and ran with `cargo run --example grovers` from
+the root directory.
 
 ```rust,ignore
 use quantr::circuit::{printer::Printer, Circuit, Measurement, StandardGate};

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -1,3 +1,13 @@
+/*
+* Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
+* or later. You may obtain a copy of the licence at
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy 
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is 
+* found in the root directory of this repository.
+*
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com> 
+*/
+
 use quantr::circuit::{printer::Printer, Circuit, Measurement, StandardGate};
 
 fn main() {

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -1,11 +1,11 @@
 /*
 * Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
 * or later. You may obtain a copy of the licence at
-* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy 
-* of the EUPL-1.2 licence in English is given in LICENCE.txt which is 
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is
 * found in the root directory of this repository.
 *
-* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com> 
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
 use quantr::circuit::{printer::Printer, Circuit, Measurement, StandardGate};

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -51,7 +51,7 @@ pub enum Measurement<T> {
 
 /// Gates that can be added to a [Circuit] struct.
 ///
-/// Matrix representations of these gates can be found at 
+/// Matrix representations of these gates can be found at
 /// [https://www.quantum-inspire.com/kbase/cqasm-qubit-gate-operations/].
 ///
 /// Currently, this enum has the `#[non_exhaustive]` as it's

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -252,6 +252,10 @@ impl Printer<'_> {
         match gate {
             StandardGate::X => "X".to_string(),
             StandardGate::H => "H".to_string(),
+            StandardGate::S => "S".to_string(),
+            StandardGate::Sdag => "S†".to_string(),
+            StandardGate::T => "T".to_string(),
+            StandardGate::Tdag => "T†".to_string(),
             StandardGate::Y => "Y".to_string(),
             StandardGate::Z => "Z".to_string(),
             StandardGate::Swap(_) => "Sw".to_string(),

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -15,7 +15,7 @@
 
 use crate::circuit::states::{ProductState, Qubit, SuperPosition};
 use crate::complex::Complex;
-use crate::{complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero, complex};
+use crate::{complex, complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero};
 use std::f64::consts::FRAC_1_SQRT_2;
 
 // The following gates (inlcuding triple and custom) are mapping qubits via the

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -15,7 +15,7 @@
 
 use crate::circuit::states::{ProductState, Qubit, SuperPosition};
 use crate::complex::Complex;
-use crate::{complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero};
+use crate::{complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero, complex};
 use std::f64::consts::FRAC_1_SQRT_2;
 
 // The following gates (inlcuding triple and custom) are mapping qubits via the
@@ -45,6 +45,38 @@ pub fn hadamard(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes(match register {
         Qubit::Zero => &complex_Re_array!(FRAC_1_SQRT_2, FRAC_1_SQRT_2),
         Qubit::One => &complex_Re_array!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2),
+    }).unwrap()
+}
+
+#[rustfmt::skip]
+pub fn tgate(register: Qubit) -> SuperPosition {
+    SuperPosition::new(1).set_amplitudes(match register {
+        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, FRAC_1_SQRT_2)],
+    }).unwrap()
+}
+
+#[rustfmt::skip]
+pub fn tgatedag(register: Qubit) -> SuperPosition {
+    SuperPosition::new(1).set_amplitudes(match register {
+        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2)],
+    }).unwrap()
+}
+
+#[rustfmt::skip]
+pub fn phase(register: Qubit) -> SuperPosition {
+    SuperPosition::new(1).set_amplitudes(match register {
+        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::One => &[complex_zero!(), complex_Im!(1f64)],
+    }).unwrap()
+}
+
+#[rustfmt::skip]
+pub fn phasedag(register: Qubit) -> SuperPosition {
+    SuperPosition::new(1).set_amplitudes(match register {
+        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::One => &[complex_zero!(), complex_Im!(-1f64)],
     }).unwrap()
 }
 


### PR DESCRIPTION
I acknowledge that:

- [x] my code passes all tests by running `cargo test`;
- [x] my code is formatted with `cargo fmt`;
- [x] I have added unit testing to test my new code (if applicable);
- [x] I have signed off on all commits with my name and email;
- [x] I have answered all the questions below and given justification
  where appropriate; and
- [x] I am merging with the `dev` branch.

## What is the current problem, or feature that should be added?

_What aspect of the project needs changing?_

There were no phase gates (denoted by S) nor T gates. These are elementary gates, and perhaps more importantly, are part of the universal set of gates for any quantum circuit.

## How does this fix and/or better quantr?

_If it's a feature, please add examples on how you would use it._ 

Adding these gates, and their conjugates, not only expands the available standard gates for the user, but in theory any quantum circuit can be built from using CNOT, H, S and T.

## Is this pull request a major or minor change with respect to the `dev` branch?

_Please refer to [semantic versioning for Rust](https://doc.rust-lang.org/cargo/reference/semver.html). If this is a major/breaking change, please add an explanation to why it could not be minor, or equally why it should break the current version._

Minor.

## What do the unit tests cover?

_Description of the unit tests added (if applicable)._

Two tests added to test S and T gates, in addition to their conjugates.

## Additional comments.

_Any more justifications, examples of output, or even suggestions for improving this pull request template are all welcome!_
