### PR TITLE
Feat registers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ I acknowledge that:
 - [] my code is formatted with `cargo fmt`;
 - [] my code successfully compiles the documentation without warnings
   using `cargo doc`;
+- [] I have updated CHANGELOG.md documenting what was changed/added;
 - [] I have added unit testing to test my new code (if applicable);
 - [] I have signed off on all commits with my name and email;
 - [] I have answered all the questions below and given justification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file logs the versions of quantr.
 
 Features:
 
+- `SuperPosition` now has a new publicly available filed that specifies
+  the product dimension of the superposition (the number of qubits in
+  each computational state).
+- Added `Circuit::simulate_with_register`, which allows to attach a
+  custom register defined by a `SuperPosition`.
 - All gates from the cQASM instruction set have now been added. The
   gates that were added to complete this set are:
   - Rx (Rotation around x-axis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file logs the versions of quantr.
 
 Features:
 
-- `SuperPosition` now has a new publicly available filed that specifies
+- `SuperPosition` now has a new publicly available field that specifies
   the product dimension of the superposition (the number of qubits in
   each computational state).
 - Added `Circuit::simulate_with_register`, which allows to attach a
@@ -34,6 +34,12 @@ Fixes:
   diagrams.
 - A warning has now been added when ASCII strings are used to label
   custom functions.
+
+Optimisations:
+
+- A new method in `SuperPosition` was added to bypass checks on
+  conservation of probability for standard gates (that have been checked
+  manually).
 
 ## 0.2.4 - Add S (Phase) and T gates
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -656,6 +656,72 @@ impl<'a> Circuit<'a> {
         self.output_state = Some(register);
     }
 
+    /// Attaches a custom register to the circuit resulting in a superposition that can be measured.
+    ///
+    /// See [Circuit::get_superposition] and [Circuit::repeat_measurement] for details on obtaining
+    /// observables from the resulting superposition.
+    ///
+    /// # Example
+    /// ```
+    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::circuit::states::{Qubit, ProductState, SuperPosition};
+    ///
+    /// let mut circuit = Circuit::new(2).unwrap();
+    /// circuit.add_gate(StandardGate::X, 1).unwrap();
+    ///
+    /// let register: SuperPosition = ProductState::new(&[Qubit::One,
+    ///                                 Qubit::Zero]).to_super_position();
+    ///
+    /// circuit.simulate_with_register(register);
+    ///
+    /// // Simulates the circuit:
+    /// // |1> -------
+    /// // |0> -- X --
+    /// ````
+    pub fn simulate_with_register(&mut self, mut register: SuperPosition) -> Result<(), QuantrError> {
+        if register.product_dim != self.num_qubits {
+            return Err(QuantrError {
+                message: format!("The custom register has a product state dimension of {}, while the number of qubits is {}. These must equal each other.", register.product_dim, self.num_qubits)
+            });
+        }
+        
+        let mut qubit_counter: usize = 0;
+        let number_gates: usize = self.circuit_gates.len();
+
+        if self.config_progress {
+            println!("Starting circuit simulation...")
+        }
+
+        // Loop through each gate of circuit from starting at top row to bottom, then moving onto the next.
+        for gate in &self.circuit_gates {
+            let gate_pos: usize = qubit_counter % self.num_qubits;
+
+            if self.config_progress {
+                Self::print_circuit_log(gate, &gate_pos, &qubit_counter, &number_gates);
+            }
+
+            if *gate == StandardGate::Id {
+                qubit_counter += 1;
+                continue;
+            }
+
+            let gate_class: GateSize = Self::classify_gate_size(gate);
+            let gate_to_apply: GateInfo = GateInfo {
+                name: gate.clone(),
+                position: gate_pos,
+                size: gate_class,
+            };
+            register = Circuit::apply_gate(&gate_to_apply, &register);
+
+            qubit_counter += 1;
+        }
+
+        self.output_state = Some(register);
+        Ok(())
+    }
+
+
+
     // If the user toggles the log on, then prints the simulation of each circuit.
     fn print_circuit_log(
         gate: &StandardGate,
@@ -1440,4 +1506,30 @@ mod tests {
         compare_circuit(circuit, &correct_register);
     }
 
+    #[test]
+    fn custom_register() {
+        let mut circuit = Circuit::new(3).unwrap();
+        circuit.add_gate(StandardGate::X, 1).unwrap();
+        let register: SuperPosition = ProductState::new(&[Qubit::One,
+                                                        Qubit::Zero, 
+                                                        Qubit::One]).to_super_position();
+        circuit.simulate_with_register(register).unwrap();
+
+        let correct_register = [
+            complex_zero!(), complex_zero!(), complex_zero!(), complex_zero!(),
+            complex_zero!(), complex_zero!(), complex_zero!(), complex_Re!(1f64)
+        ];
+        
+        compare_circuit(circuit, &correct_register);
+    }
+
+    #[test]
+    #[should_panic]
+    fn custom_register_wrong_dimension() {
+        let mut circuit = Circuit::new(3).unwrap();
+        circuit.add_gate(StandardGate::X, 1).unwrap();
+        let register: SuperPosition = ProductState::new(&[Qubit::One, Qubit::Zero]).to_super_position();
+        circuit.simulate_with_register(register).unwrap();
+
+    }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -678,13 +678,16 @@ impl<'a> Circuit<'a> {
     /// // |1> -------
     /// // |0> -- X --
     /// ````
-    pub fn simulate_with_register(&mut self, mut register: SuperPosition) -> Result<(), QuantrError> {
+    pub fn simulate_with_register(
+        &mut self,
+        mut register: SuperPosition,
+    ) -> Result<(), QuantrError> {
         if register.product_dim != self.num_qubits {
             return Err(QuantrError {
                 message: format!("The custom register has a product state dimension of {}, while the number of qubits is {}. These must equal each other.", register.product_dim, self.num_qubits)
             });
         }
-        
+
         let mut qubit_counter: usize = 0;
         let number_gates: usize = self.circuit_gates.len();
 
@@ -719,8 +722,6 @@ impl<'a> Circuit<'a> {
         self.output_state = Some(register);
         Ok(())
     }
-
-
 
     // If the user toggles the log on, then prints the simulation of each circuit.
     fn print_circuit_log(

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -35,7 +35,7 @@ use std::ops::{Div, Mul};
 
 #[rustfmt::skip]
 pub fn identity(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex_Re!(1f64)],
     }).unwrap()
@@ -43,7 +43,7 @@ pub fn identity(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn hadamard(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &complex_Re_array!(FRAC_1_SQRT_2, FRAC_1_SQRT_2),
         Qubit::One => &complex_Re_array!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2),
     }).unwrap()
@@ -56,7 +56,7 @@ pub fn rx(register: Qubit, angle: f64) -> SuperPosition {
     let zero_map: [Complex<f64>; 2] = [real_parts, imaginary_part];
     let one_map: [Complex<f64>; 2] = [imaginary_part, real_parts];
 
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
         Qubit::One => &one_map,
     }).unwrap()
@@ -70,7 +70,7 @@ pub fn ry(register: Qubit, angle: f64) -> SuperPosition {
     let zero_map: [Complex<f64>; 2] = [cos_parts, sin_part_pos];
     let one_map: [Complex<f64>; 2] = [sin_part_neg, cos_parts];
 
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
         Qubit::One => &one_map,
     }).unwrap()
@@ -83,7 +83,7 @@ pub fn rz(register: Qubit, angle: f64) -> SuperPosition {
     let zero_map: [Complex<f64>; 2] = [neg_exp, complex_zero!()];
     let one_map: [Complex<f64>; 2] = [complex_zero!(), pos_exp];
 
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
         Qubit::One => &one_map,
     }).unwrap()
@@ -95,7 +95,7 @@ pub fn global_phase(register: Qubit, angle: f64) -> SuperPosition {
     let zero_map: [Complex<f64>; 2] = [exp, complex_zero!()];
     let one_map: [Complex<f64>; 2] = [complex_zero!(), exp];
 
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
         Qubit::One => &one_map,
     }).unwrap()
@@ -103,7 +103,7 @@ pub fn global_phase(register: Qubit, angle: f64) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn x90(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Im!(-1f64)],
         Qubit::One => &[complex_Im!(-1f64), complex_zero!()],
     }).unwrap()
@@ -111,7 +111,7 @@ pub fn x90(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn y90(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Re!(-1f64)],
         Qubit::One => &[complex_Re!(1f64), complex_zero!()],
     }).unwrap()
@@ -119,7 +119,7 @@ pub fn y90(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn mx90(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Im!(1f64)],
         Qubit::One => &[complex_Im!(1f64), complex_zero!()],
     }).unwrap()
@@ -127,7 +127,7 @@ pub fn mx90(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn my90(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Re!(1f64)],
         Qubit::One => &[complex_Re!(-1f64), complex_zero!()],
     }).unwrap()
@@ -135,7 +135,7 @@ pub fn my90(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn tgate(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, FRAC_1_SQRT_2)],
     }).unwrap()
@@ -143,7 +143,7 @@ pub fn tgate(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn tgatedag(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2)],
     }).unwrap()
@@ -151,7 +151,7 @@ pub fn tgatedag(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn phase(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex_Im!(1f64)],
     }).unwrap()
@@ -159,7 +159,7 @@ pub fn phase(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn phasedag(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex_Im!(-1f64)],
     }).unwrap()
@@ -167,7 +167,7 @@ pub fn phasedag(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn pauli_x(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Re!(1f64)],
         Qubit::One => &[complex_Re!(1f64), complex_zero!()],
     }).unwrap()
@@ -175,7 +175,7 @@ pub fn pauli_x(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn pauli_y(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_zero!(), complex_Im!(1f64)],
         Qubit::One => &[complex_Im!(-1f64), complex_zero!()],
     }).unwrap()
@@ -183,7 +183,7 @@ pub fn pauli_y(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn pauli_z(register: Qubit) -> SuperPosition {
-    SuperPosition::new(1).set_amplitudes(match register {
+    SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
         Qubit::One => &[complex_zero!(), complex_Re!(-1f64)],
     }).unwrap()
@@ -196,7 +196,7 @@ pub fn pauli_z(register: Qubit) -> SuperPosition {
 #[rustfmt::skip]
 pub fn cnot(register: ProductState) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Re_array!(0f64, 0f64, 0f64, 1f64),
@@ -207,7 +207,7 @@ pub fn cnot(register: ProductState) -> SuperPosition {
 #[rustfmt::skip]
 pub fn cy(register: ProductState) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Im_array!(0f64, 0f64, 0f64, 1f64),
@@ -218,7 +218,7 @@ pub fn cy(register: ProductState) -> SuperPosition {
 #[rustfmt::skip]
 pub fn cz(register: ProductState) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Re_array!(0f64, 0f64, 1f64, 0f64),
@@ -229,7 +229,7 @@ pub fn cz(register: ProductState) -> SuperPosition {
 #[rustfmt::skip]
 pub fn swap(register: ProductState) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 0f64, 1f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -241,7 +241,7 @@ pub fn swap(register: ProductState) -> SuperPosition {
 pub fn cr(register: ProductState, angle: f64) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
     let exp_array: [Complex<f64>; 4] = [complex_zero!(), complex_zero!(), complex_zero!(), Complex::<f64>::expi(angle)];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Re_array!(0f64, 0f64, 1f64, 0f64),
@@ -254,7 +254,7 @@ pub fn crk(register: ProductState, k: i32) -> SuperPosition {
     let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
     let exp_array: [Complex<f64>; 4] = 
         [complex_zero!(), complex_zero!(), complex_zero!(), Complex::<f64>::expi((2f64*std::f64::consts::PI).div(2f64.powi(k)))];
-    SuperPosition::new(2).set_amplitudes(match input_register {
+    SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => &complex_Re_array!(0f64, 0f64, 1f64, 0f64),
@@ -270,7 +270,7 @@ pub fn crk(register: ProductState, k: i32) -> SuperPosition {
 pub fn toffoli(register: ProductState) -> SuperPosition {
     let input_register: [Qubit; 3] = [register.state[0], register.state[1], register.state[2]];
     SuperPosition::new(3)
-        .set_amplitudes(match input_register {
+        .set_amplitudes_unchecked(match input_register {
             [Qubit::Zero, Qubit::Zero, Qubit::Zero] => {&complex_Re_array!(1f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64) }
             [Qubit::Zero, Qubit::Zero, Qubit::One] => { &complex_Re_array!(0f64, 1f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64) }
             [Qubit::Zero, Qubit::One, Qubit::Zero] => { &complex_Re_array!(0f64, 0f64, 1f64, 0f64, 0f64, 0f64, 0f64, 0f64) }

--- a/src/circuit/states.rs
+++ b/src/circuit/states.rs
@@ -192,7 +192,7 @@ impl ProductState {
 #[derive(PartialEq, Debug, Clone)]
 pub struct SuperPosition {
     pub amplitudes: Vec<Complex<f64>>,
-    product_dim: usize,
+    pub product_dim: usize,
     index: usize,
 }
 

--- a/src/circuit/states.rs
+++ b/src/circuit/states.rs
@@ -326,7 +326,10 @@ impl SuperPosition {
         num < compare_num + Self::ERROR_MARGIN && num > compare_num - Self::ERROR_MARGIN
     }
 
-    pub(crate) fn set_amplitudes_unchecked(self, amplitudes: &[Complex<f64>]) -> Result<SuperPosition, QuantrError> {
+    pub(crate) fn set_amplitudes_unchecked(
+        self,
+        amplitudes: &[Complex<f64>],
+    ) -> Result<SuperPosition, QuantrError> {
         let mut new_amps: Vec<Complex<f64>> = (*self.amplitudes).to_vec();
         Self::copy_slice_to_vec(&mut new_amps, amplitudes);
         Ok(SuperPosition {

--- a/src/circuit/states.rs
+++ b/src/circuit/states.rs
@@ -326,6 +326,16 @@ impl SuperPosition {
         num < compare_num + Self::ERROR_MARGIN && num > compare_num - Self::ERROR_MARGIN
     }
 
+    pub(crate) fn set_amplitudes_unchecked(self, amplitudes: &[Complex<f64>]) -> Result<SuperPosition, QuantrError> {
+        let mut new_amps: Vec<Complex<f64>> = (*self.amplitudes).to_vec();
+        Self::copy_slice_to_vec(&mut new_amps, amplitudes);
+        Ok(SuperPosition {
+            amplitudes: new_amps,
+            product_dim: self.product_dim,
+            index: 0,
+        })
+    }
+
     /// Returns a superposition constructed from a HashMap with [ProductState] keys and amplitudes
     /// that are `Complex<f64>` values.
     ///


### PR DESCRIPTION
I acknowledge that:

- [x] my code passes all tests by running `cargo test`;
- [x] my code is formatted with `cargo fmt`;
- [x] I have added unit testing to test my new code (if applicable);
- [x] I have signed off on all commits with my name and email;
- [x] I have answered all the questions below and given justification
  where appropriate; and
- [x] I am merging with the `dev` branch.

## What is the current problem, or feature that should be added?

_What aspect of the project needs changing?_

There is no way to attach a custom register to the circuit. 

## How does this fix and/or better quantr?

_If it's a feature, please add examples on how you would use it._ 

Even though registers can always be started in the zero state, if there were multiple circuits at play, two circuits can now be "connected" so one can offload it's superposition to be the register of another.

## Is this pull request a major or minor change with respect to the `dev` branch?

_Please refer to [semantic versioning for Rust](https://doc.rust-lang.org/cargo/reference/semver.html). If this is a major/breaking change, please add an explanation to why it could not be minor, or equally why it should break the current version._

Minor

## What do the unit tests cover?

_Description of the unit tests added (if applicable)._

Tests for adding a custom register, and incorrect custom register were added.

## Additional comments.

_Any more justifications, examples of output, or even suggestions for improving this pull request template are all welcome!_
