### PR TITLE
Feat optimise interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,43 @@ This file logs the versions of quantr.
 
 ## 0.3.0 - UNTITLED
 
+This major update overhauls the structure of quantr, and the naming of
+many methods. The aim is to increase simplicity in using the library,
+in turn producing more readable and efficient code.
+
+Moreover, some examples have been added showcasing custom functions and
+printing the circuits in a variety of ways. 
+
 Features:
 
-- Re-structured access of structs and module paths. Now, every struct
-  is accessed through `quantr::...` except for those that control
-  states, which are accessed through the module `quantr::states::...`.
+- The `QuantrError` struct has been made public for the user (this was
+  available in versions < 0.2.0). This allows for succint error handling
+  with `?` when creating circuits when the main function is allowed to
+  return `Result<(), QuantrError>`.
+- Re-structured access of structs and module paths. Now, every struct is
+  accessed through `quantr::...` except for those that control states,
+  which are accessed through the module `quantr::states::...`.
 - Changed the input type of two methods in `Circuit`:
     - `add_gates(Vec<Gate>)` -> `add_gates(&[Gate])`
     - `add_repeating_gate(Gate, Vec<usize>)` ->
       `add_repeating_gate(Gate, &[usize])`.
 - `Circuit` methods that add gates now output a mutable reference to the
   mutated circuit. This allows for a 'chain of method calls' to be made.
+
+Examples:
+
+All examples print the circuit to the console, along with data of the
+resulting superpositions from simulating the circuit.
+
+- A custom function implementing a Quantum Fourier Transform in
+  `examples/qft.rs` which is designed to be used in other circuits. This
+  also showcases the idea of running a circuit within a custom function,
+  in a way sub-divding components of the larger circuit into smaller
+  ones.
+- The custom function itself, implementing a CCC-not gate, is shown in
+  `examples/custom_gates.rs`. Within this function, the product states
+  are directly manipulated to produce a CCC-not gate. This example also
+  prints the progress of the simulation.
 
 Tests:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file logs the versions of quantr.
 
+## 0.3.0 - UNTITLED
+
+Features:
+- Re-structured access of structs and module paths. Now, every struct
+  is accessed through `quantr::...` except for those that control
+  states, which are accessed through the module `quantr::states::...`.
+
 ## 0.2.5 - Complex exponential, ASCII warnings and gates
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,21 @@ This file logs the versions of quantr.
 ## 0.3.0 - UNTITLED
 
 Features:
+
 - Re-structured access of structs and module paths. Now, every struct
   is accessed through `quantr::...` except for those that control
   states, which are accessed through the module `quantr::states::...`.
+- Changed the input type of two methods in `Circuit`:
+    - `add_gates(Vec<Gate>)` -> `add_gates(&[Gate])`
+    - `add_repeating_gate(Gate, Vec<usize>)` ->
+      `add_repeating_gate(Gate, &[usize])`.
+- `Circuit` methods that add gates now output a mutable reference to the
+  mutated circuit. This allows for a 'chain of method calls' to be made.
+
+Tests:
+
+- All tests and examples have been updated to reflect this major change.
+  Now answers had to be changed, only the interfaces with quantr.
 
 ## 0.2.5 - Complex exponential, ASCII warnings and gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ printing the circuits in a variety of ways.
 
 Features:
 
+- Renamed the enum `StandardGate` to `Gate`.
 - The `complex_zero!` macro has been replaced with a `Complex<f64>`
   constant `quantr::COMPLEX_ZERO`. 
 - Changed method names:
@@ -59,6 +60,8 @@ Tests:
 
 - All tests and examples have been updated to reflect this major change.
   Now answers had to be changed, only the interfaces with quantr.
+- Boundary test to catch if a control node is greater than the size of
+  the circuit.
 
 ## 0.2.5 - Complex exponential, ASCII warnings and gates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ into the method.
 Moreover, some examples have been added showcasing custom functions and
 printing the circuits in a variety of ways. 
 
-Features:
+Breaking Changes:
 
+- Renamed the fields of `Complex` from `real` and `imaginary` to `re`
+  and `im` respectively. 
 - Removed `Circuit::simulate_with_register`. This is replaced with
-  `Circuit::change_register` which can be called before simualtion, to
+  `Circuit::change_register` which can be called before simulation, to
   change the default register of |00..0> that is applied during
   simulating.
 - Removed `Printer::flush` as it cannot be used due to borrowing rules.
@@ -33,10 +35,6 @@ Features:
     - `ProductState::to_super_position` ->
       `ProductState::into_super_position`
 - The field of `ProductState` called `state` -> `qubits`.
-- The `QuantrError` struct has been made public for the user (this was
-  available in versions < 0.2.0). This allows for succint error handling
-  with `?` when creating circuits when the main function is allowed to
-  return `Result<(), QuantrError>`.
 - Re-structured access of structs and module paths. Now, every struct is
   accessed through `quantr::...` except for those that control states,
   which are accessed through the module `quantr::states::...`.
@@ -46,6 +44,13 @@ Features:
       `add_repeating_gate(Gate, &[usize])`.
 - `Circuit` methods that add gates now output a mutable reference to the
   mutated circuit. This allows for a 'chain of method calls' to be made.
+
+Features:
+
+- The `QuantrError` struct has been made public for the user (this was
+  available in versions < 0.2.0). This allows for succinct error handling
+  with `?` when creating circuits when the main function is allowed to
+  return `Result<(), QuantrError>`.
 
 Examples:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ printing the circuits in a variety of ways.
 
 Features:
 
+- Removed `Circuit::simulate_with_register`. This is replaced with
+  `Circuit::change_register` which can be called before simualtion, to
+  change the default register of |00..0> that is applied during
+  simulating.
 - Removed `Printer::flush` as it cannot be used due to borrowing rules.
 - Renamed the enum `StandardGate` to `Gate`.
 - The `complex_zero!` macro has been replaced with a `Complex<f64>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ printing the circuits in a variety of ways.
 
 Features:
 
+- Removed `Printer::flush` as it cannot be used due to borrowing rules.
 - Renamed the enum `StandardGate` to `Gate`.
 - The `complex_zero!` macro has been replaced with a `Complex<f64>`
   constant `quantr::COMPLEX_ZERO`. 
@@ -25,7 +26,8 @@ Features:
     - `ProductState::join` -> `ProductState::kronecker_prod`
     - `ProductState::as_string` -> `ProductState::to_string`
     - `SuperPosition::as_hash_map` -> `SuperPosition::to_hash_map`
-    - `ProductState::to_super_position` -> `ProductState::into_super_position`
+    - `ProductState::to_super_position` ->
+      `ProductState::into_super_position`
 - The field of `ProductState` called `state` -> `qubits`.
 - The `QuantrError` struct has been made public for the user (this was
   available in versions < 0.2.0). This allows for succint error handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,26 @@ This file logs the versions of quantr.
 
 This major update overhauls the structure of quantr, and the naming of
 many methods. The aim is to increase simplicity in using the library,
-in turn producing more readable and efficient code.
+in turn producing more readable and efficient code. The re-naming of
+methods is meant to be more inkeeping with the Rust standard library,
+that is `to` represents a pass by reference, while `into` moves the value
+into the method.
 
 Moreover, some examples have been added showcasing custom functions and
 printing the circuits in a variety of ways. 
 
 Features:
 
+- The `complex_zero!` macro has been replaced with a `Complex<f64>`
+  constant `quantr::COMPLEX_ZERO`. 
+- Changed method names:
+    - `Qubit::join` -> `Qubit::kronecker_prod`
+    - `Qubit::as_state` -> `Qubit::into_state`
+    - `ProductState::join` -> `ProductState::kronecker_prod`
+    - `ProductState::as_string` -> `ProductState::to_string`
+    - `SuperPosition::as_hash_map` -> `SuperPosition::to_hash_map`
+    - `ProductState::to_super_position` -> `ProductState::into_super_position`
+- The field of `ProductState` called `state` -> `qubits`.
 - The `QuantrError` struct has been made public for the user (this was
   available in versions < 0.2.0). This allows for succint error handling
   with `?` when creating circuits when the main function is allowed to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Andrew Barlow <a.barlow.dev@gmail.com>"]
 repository = "https://github.com/a-barlow/quantr"
 homepage = "https://a-barlow.github.io/quantr-book"
 description = "Readily create, simulate and print quantum circuits."
+publish = false
 
 [dependencies]
 rand = "0.8.5"

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -159,6 +159,25 @@ This completes the construction and measurement of a three qubit
 Grover's circuit. Other functions (which include examples in their
 documentation) can add gates in other ways.
 
+To improve on the readability of this code by removing the numerous
+`unwrap()` calls, the main function declaration can be edited like so:
+
+```rust,ignore 
+use quantr::QuantrError;
+
+fn main() -> Result<(), QuantrError> {...; Ok(()) }
+```
+
+with a `Ok(())` returned on the last line; signifying that the program
+has exited without errors. Then, effectively all unwrap methods called
+after appending gates can be replaced with a `?`. However, an argument
+for leaving the unwraps explicit is that if a function has appended a
+gate resulting in an error, such as adding a gate outwidth the circuit's
+size, then at runtime the program will panic and return a compiler
+message explicitly directing the user to the line in question. Even
+though the many unwraps may be unpleasant, it can be benificial for
+debugging while creating the circuit.
+
 The following is the completed code. This can also be found in
 `examples/grovers.rs`, and ran with `cargo run --example grovers` from
 the root directory.
@@ -220,7 +239,7 @@ fn main() {
     {
         println!("\n[Non-Observable] The amplitudes of each state in the final superposition.");
         for (state, amplitude) in output_super_position.into_iter() {
-            println!("|{}> : {}", state.as_string(), amplitude);
+            println!("|{}> : {}", state.to_string(), amplitude);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ fn main() {
     if let Observable(bin_count) = quantum_circuit.repeat_measurement(500).unwrap() {
         println!("[Observable] Bin count of observed states.");
         for (state, count) in bin_count {
-            println!("|{}> observed {} times", state.as_string(), count);
+            println!("|{}> observed {} times", state.to_string(), count);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # 🚧 quantr 🚧 
 
-[![Static
-Badge](https://img.shields.io/badge/Version%20-%201.73.0%20-%20%20(185%2C71%2C0)?style=fat&logo=rust&color=%23B94700)](https://releases.rs/)
-[![cargo
-test](https://github.com/a-barlow/quantr/workflows/cargo%20test/badge.svg)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
-[![cargo test
-(dev)](https://github.com/a-barlow/quantr/workflows/cargo%20test%20%28dev%29/badge.svg)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
+[![Crates.io](https://img.shields.io/crates/v/quantr?style=flat-square&color=%23B94700)](https://crates.io/crates/quantr)
+[![Static Badge](https://img.shields.io/badge/version%20-%201.73.0%20-%20white?style=flat-square&logo=rust&color=%23B94700)](https://releases.rs/)
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=build%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
+![docs.rs](https://img.shields.io/docsrs/quantr?style=flat-square&color=%2349881B)
+![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&color=%23009250)
+![Crates.io](https://img.shields.io/crates/l/quantr?style=flat-square&color=%23009982)
 
 > This crate is not production ready and so should **not** be considered
 > stable, nor produce correct answers. It is still under heavy

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ implementation of Grover's algorithm.
 An example of simulating and printing a two qubit circuit:
 
 ```rust
-use quantr::circuit::{Circuit, StandardGate, printer::Printer, 
+use quantr::{Circuit, StandardGate, Printer, 
             Measurement::Observable};
 
 fn main() {

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=build%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
 ![docs.rs](https://img.shields.io/docsrs/quantr?style=flat-square&color=%2349881B)
-![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&label=licence&color=%23009250)
-![Crates.io](https://img.shields.io/crates/l/quantr?style=flat-square&color=%23009982)
+![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&color=%23009250)
+![Crates.io](https://img.shields.io/crates/l/quantr?style=flat-square&label=licence&color=%23009982)
 
 > This crate is not production ready and so should **not** be considered
 > stable, nor produce correct answers. It is still under heavy
@@ -51,8 +51,7 @@ implementation of Grover's algorithm.
 An example of simulating and printing a two qubit circuit:
 
 ```rust
-use quantr::{Circuit, StandardGate, Printer, 
-            Measurement::Observable};
+use quantr::{Circuit, StandardGate, Printer, Measurement::Observable};
 
 fn main() {
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=build%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
 ![docs.rs](https://img.shields.io/docsrs/quantr?style=flat-square&color=%2349881B)
-![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&color=%23009250)
+![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&label=licence&color=%23009250)
 ![Crates.io](https://img.shields.io/crates/l/quantr?style=flat-square&color=%23009982)
 
 > This crate is not production ready and so should **not** be considered
@@ -59,9 +59,8 @@ fn main() {
     let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
 
     quantum_circuit 
-        .add_gates(vec![StandardGate::H, StandardGate::H])
-        .unwrap();
-    quantum_circuit
+        .add_gates(&[StandardGate::H, StandardGate::H])
+        .unwrap()
         .add_gate(StandardGate::CNot(0), 1)
         .unwrap();
     

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ implementation of Grover's algorithm.
 An example of simulating and printing a two qubit circuit:
 
 ```rust
-use quantr::{Circuit, StandardGate, Printer, Measurement::Observable};
+use quantr::{Circuit, Gate, Printer, Measurement::Observable};
 
 fn main() {
 
     let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
-
+    
     quantum_circuit 
-        .add_gates(&[StandardGate::H, StandardGate::H]).unwrap()
-        .add_gate(StandardGate::CNot(0), 1).unwrap();
+        .add_gates(&[Gate::H, Gate::H]).unwrap()
+        .add_gate(Gate::CNot(0), 1).unwrap();
     
     let mut printer = Printer::new(&quantum_circuit);
     printer.print_diagram();

--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ fn main() {
     let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
 
     quantum_circuit 
-        .add_gates(&[StandardGate::H, StandardGate::H])
-        .unwrap()
-        .add_gate(StandardGate::CNot(0), 1)
-        .unwrap();
+        .add_gates(&[StandardGate::H, StandardGate::H]).unwrap()
+        .add_gate(StandardGate::CNot(0), 1).unwrap();
     
     let mut printer = Printer::new(&quantum_circuit);
     printer.print_diagram();

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/quantr?style=flat-square&color=%23B94700)](https://crates.io/crates/quantr)
 [![Static Badge](https://img.shields.io/badge/version%20-%201.73.0%20-%20white?style=flat-square&logo=rust&color=%23B94700)](https://releases.rs/)
-[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
-[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=build%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&label=tests&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=tests%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
 ![docs.rs](https://img.shields.io/docsrs/quantr?style=flat-square&color=%2349881B)
 ![Crates.io](https://img.shields.io/crates/d/quantr?style=flat-square&color=%23009250)
 ![Crates.io](https://img.shields.io/crates/l/quantr?style=flat-square&label=licence&color=%23009982)

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -12,7 +12,7 @@
 
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
-    Circuit, Measurement, Printer, QuantrError, Gate,
+    Circuit, Gate, Measurement, Printer, QuantrError,
 };
 
 fn main() -> Result<(), QuantrError> {
@@ -32,6 +32,7 @@ fn main() -> Result<(), QuantrError> {
 
     // Prints the bin count of measured states.
     if let Measurement::Observable(bin_count) = qc.repeat_measurement(50).unwrap() {
+        println!("\nStates observed over 50 measurements:");
         for (states, count) in bin_count.into_iter() {
             println!("|{}> : {}", states.to_string(), count);
         }

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -1,0 +1,55 @@
+/*
+* Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
+* or later. You may obtain a copy of the licence at
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is
+* found in the root directory of this repository.
+*
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
+*/
+
+// Details an implementation of a CCC-not gate.
+
+use quantr::{
+    states::{ProductState, Qubit, SuperPosition},
+    Circuit, Measurement, Printer, StandardGate,
+};
+
+fn main() {
+    let mut qc: Circuit = Circuit::new(4).unwrap();
+
+    // Build a circuit with thre CCC-not gate, placing the control nodes on positions 0, 1, 2 and
+    // the target on 3.
+    qc.add_repeating_gate(StandardGate::X, &[0, 1, 2])
+        .unwrap()
+        .add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)
+        .unwrap();
+
+    // Let us print the circuit, viewing the custom gate, and then simulating it.
+    let mut circuit_printer: Printer = Printer::new(&qc);
+    circuit_printer.print_diagram();
+    qc.simulate();
+
+    if let Measurement::Observable(bin_count) = qc.repeat_measurement(50).unwrap() {
+        for (states, count) in bin_count.into_iter() {
+            println!("|{}> : {}", states.as_string(), count);
+        }
+    }
+}
+
+fn cccnot(input_state: ProductState) -> SuperPosition {
+    let state: Vec<Qubit> = input_state.state;
+    let state_slice: [Qubit; 4] = [state[0], state[1], state[2], state[3]]; // In this format, this
+                                                                            // guarantees that state_slice has length 4 to the rust compiler. Useful for the match
+                                                                            // statement.
+    match state_slice {
+        [Qubit::One, Qubit::One, Qubit::One, Qubit::Zero] => {
+            ProductState::new(&[Qubit::One; 4]).to_super_position()
+        }
+        [Qubit::One, Qubit::One, Qubit::One, Qubit::One] => {
+            ProductState::new(&[Qubit::One, Qubit::One, Qubit::One, Qubit::Zero])
+                .to_super_position()
+        }
+        other_state => ProductState::new(&other_state).to_super_position(),
+    }
+}

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -12,22 +12,22 @@
 
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
-    Circuit, Measurement, Printer, StandardGate,
+    Circuit, Measurement, Printer, StandardGate, QuantrError,
 };
 
-fn main() {
-    let mut qc: Circuit = Circuit::new(4).unwrap();
+fn main() -> Result<(), QuantrError> {
+    let mut qc: Circuit = Circuit::new(4)?;
 
     // Build a circuit using a CCC-not gate, placing the control nodes on positions 0, 1, 2 and
     // the target on 3.
-    qc.add_repeating_gate(StandardGate::X, &[0, 1, 2])
-        .unwrap()
-        .add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)
-        .unwrap();
+    qc.add_repeating_gate(StandardGate::X, &[0, 1, 2])?
+        .add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)?;
 
     // Prints the circuit, viewing the custom gate, and then simulating it.
     let mut circuit_printer: Printer = Printer::new(&qc);
     circuit_printer.print_diagram();
+    
+    qc.toggle_simulation_progress(); // prints the simulation toggle_simulation_progress
     qc.simulate();
 
     // Prints the bin count of measured states.
@@ -36,6 +36,8 @@ fn main() {
             println!("|{}> : {}", states.as_string(), count);
         }
     }
+
+    Ok(())
 }
 
 // Implements the CCC-not gate.

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -8,11 +8,11 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-// Shows the use of `StandardGate::Custom` in implementing the CCC-not gate.
+// Shows the use of `Gate::Custom` in implementing the CCC-not gate.
 
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
-    Circuit, Measurement, Printer, QuantrError, StandardGate,
+    Circuit, Measurement, Printer, QuantrError, Gate,
 };
 
 fn main() -> Result<(), QuantrError> {
@@ -20,8 +20,8 @@ fn main() -> Result<(), QuantrError> {
 
     // Build a circuit using a CCC-not gate, placing the control nodes on positions 0, 1, 2 and
     // the target on 3.
-    qc.add_repeating_gate(StandardGate::X, &[0, 1, 2])?
-        .add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)?;
+    qc.add_repeating_gate(Gate::X, &[0, 1, 2])?
+        .add_gate(Gate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)?;
 
     // Prints the circuit, viewing the custom gate, and then simulating it.
     let mut circuit_printer: Printer = Printer::new(&qc);

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -12,7 +12,7 @@
 
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
-    Circuit, Measurement, Printer, StandardGate, QuantrError,
+    Circuit, Measurement, Printer, QuantrError, StandardGate,
 };
 
 fn main() -> Result<(), QuantrError> {
@@ -26,14 +26,14 @@ fn main() -> Result<(), QuantrError> {
     // Prints the circuit, viewing the custom gate, and then simulating it.
     let mut circuit_printer: Printer = Printer::new(&qc);
     circuit_printer.print_diagram();
-    
+
     qc.toggle_simulation_progress(); // prints the simulation toggle_simulation_progress
     qc.simulate();
 
     // Prints the bin count of measured states.
     if let Measurement::Observable(bin_count) = qc.repeat_measurement(50).unwrap() {
         for (states, count) in bin_count.into_iter() {
-            println!("|{}> : {}", states.as_string(), count);
+            println!("|{}> : {}", states.to_string(), count);
         }
     }
 
@@ -42,18 +42,18 @@ fn main() -> Result<(), QuantrError> {
 
 // Implements the CCC-not gate.
 fn cccnot(input_state: ProductState) -> SuperPosition {
-    let state: Vec<Qubit> = input_state.state;
+    let state: Vec<Qubit> = input_state.qubits;
     let state_slice: [Qubit; 4] = [state[0], state[1], state[2], state[3]]; // In this format, this
                                                                             // guarantees that state_slice has length 4 to the rust compiler. Useful for the match
                                                                             // statement.
     match state_slice {
         [Qubit::One, Qubit::One, Qubit::One, Qubit::Zero] => {
-            ProductState::new(&[Qubit::One; 4]).to_super_position()
+            ProductState::new(&[Qubit::One; 4]).into_super_position()
         }
         [Qubit::One, Qubit::One, Qubit::One, Qubit::One] => {
             ProductState::new(&[Qubit::One, Qubit::One, Qubit::One, Qubit::Zero])
-                .to_super_position()
+                .into_super_position()
         }
-        other_state => ProductState::new(&other_state).to_super_position(),
+        other_state => ProductState::new(&other_state).into_super_position(),
     }
 }

--- a/examples/custom_gate.rs
+++ b/examples/custom_gate.rs
@@ -8,7 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-// Details an implementation of a CCC-not gate.
+// Shows the use of `StandardGate::Custom` in implementing the CCC-not gate.
 
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
@@ -18,18 +18,19 @@ use quantr::{
 fn main() {
     let mut qc: Circuit = Circuit::new(4).unwrap();
 
-    // Build a circuit with thre CCC-not gate, placing the control nodes on positions 0, 1, 2 and
+    // Build a circuit using a CCC-not gate, placing the control nodes on positions 0, 1, 2 and
     // the target on 3.
     qc.add_repeating_gate(StandardGate::X, &[0, 1, 2])
         .unwrap()
         .add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 3)
         .unwrap();
 
-    // Let us print the circuit, viewing the custom gate, and then simulating it.
+    // Prints the circuit, viewing the custom gate, and then simulating it.
     let mut circuit_printer: Printer = Printer::new(&qc);
     circuit_printer.print_diagram();
     qc.simulate();
 
+    // Prints the bin count of measured states.
     if let Measurement::Observable(bin_count) = qc.repeat_measurement(50).unwrap() {
         for (states, count) in bin_count.into_iter() {
             println!("|{}> : {}", states.as_string(), count);
@@ -37,6 +38,7 @@ fn main() {
     }
 }
 
+// Implements the CCC-not gate.
 fn cccnot(input_state: ProductState) -> SuperPosition {
     let state: Vec<Qubit> = input_state.state;
     let state_slice: [Qubit; 4] = [state[0], state[1], state[2], state[3]]; // In this format, this

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -8,6 +8,12 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
+// A 3 qubit circuit that implementes Grovers algorithm. The oracle target the states |110> and
+// |111>. This example will also print the circuit, and show the simulaion in real time.
+//
+// This example will print s bin count of measured states from 500 repeated simulations, and the
+// superpoisition itself.
+
 use quantr::{Circuit, Measurement, Printer, StandardGate};
 
 #[rustfmt::skip]

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -14,7 +14,7 @@
 // This example will print a bin count of measured states from 500 repeated simulations, and the
 // superposition itself.
 
-use quantr::{Circuit, Measurement, Printer, QuantrError, Gate};
+use quantr::{Circuit, Gate, Measurement, Printer, QuantrError};
 
 #[rustfmt::skip]
 fn main() -> Result<(), QuantrError>{

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -8,7 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-use quantr::{Printer, Circuit, Measurement, StandardGate};
+use quantr::{Circuit, Measurement, Printer, StandardGate};
 
 #[rustfmt::skip]
 fn main() {

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -14,29 +14,27 @@
 // This example will print a bin count of measured states from 500 repeated simulations, and the
 // superposition itself.
 
-use quantr::{Circuit, Measurement, Printer, StandardGate};
+use quantr::{Circuit, Measurement, Printer, QuantrError, Gate};
 
 #[rustfmt::skip]
-fn main() {
-    let mut circuit = Circuit::new(3).unwrap();
+fn main() -> Result<(), QuantrError>{
+    let mut circuit = Circuit::new(3)?;
 
     // Kick state into superposition of equal weights
-    circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2])
-        .unwrap();
+    circuit.add_repeating_gate(Gate::H, &[0, 1, 2])?;
 
     // Oracle
-    circuit.add_gate(StandardGate::CZ(1), 0).unwrap();
+    circuit.add_gate(Gate::CZ(1), 0)?;
 
     // Amplitude amplification
     circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
-        .add_gate(StandardGate::H, 2).unwrap()
-        .add_gate(StandardGate::Toffoli(0, 1), 2).unwrap()
-        .add_gate(StandardGate::H, 2).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
+        .add_repeating_gate(Gate::H, &[0, 1, 2])?
+        .add_repeating_gate(Gate::X, &[0, 1, 2])?
+        .add_gate(Gate::H, 2)?
+        .add_gate(Gate::Toffoli(0, 1), 2)?
+        .add_gate(Gate::H, 2)?
+        .add_repeating_gate(Gate::X, &[0, 1, 2])?
+        .add_repeating_gate(Gate::H, &[0, 1, 2])?;
 
     // Prints the circuit in UTF-8
     let mut printer = Printer::new(&circuit);
@@ -66,4 +64,6 @@ fn main() {
             println!("|{}> : {}", state.to_string(), amplitude);
         }
     }
+
+    Ok(())
 }

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -15,7 +15,7 @@ fn main() {
 
     // Kick state into superposition of equal weights
     circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2])
         .unwrap();
 
     // Oracle
@@ -23,22 +23,13 @@ fn main() {
 
     // Amplitude amplification
     circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
-        .unwrap();
-    circuit
-        .add_repeating_gate(StandardGate::X, vec![0, 1, 2])
-        .unwrap();
-
-    circuit.add_gate(StandardGate::H, 2).unwrap();
-    circuit.add_gate(StandardGate::Toffoli(0, 1), 2).unwrap();
-    circuit.add_gate(StandardGate::H, 2).unwrap();
-
-    circuit
-        .add_repeating_gate(StandardGate::X, vec![0, 1, 2])
-        .unwrap();
-    circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
-        .unwrap();
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
+        .add_gate(StandardGate::H, 2).unwrap()
+        .add_gate(StandardGate::Toffoli(0, 1), 2).unwrap()
+        .add_gate(StandardGate::H, 2).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
 
     // Prints the circuit in UTF-8
     let mut printer = Printer::new(&circuit);

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -10,6 +10,7 @@
 
 use quantr::{Printer, Circuit, Measurement, StandardGate};
 
+#[rustfmt::skip]
 fn main() {
     let mut circuit = Circuit::new(3).unwrap();
 

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -8,7 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-use quantr::circuit::{printer::Printer, Circuit, Measurement, StandardGate};
+use quantr::{Printer, Circuit, Measurement, StandardGate};
 
 fn main() {
     let mut circuit = Circuit::new(3).unwrap();

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -11,8 +11,8 @@
 // A 3 qubit circuit that implementes Grovers algorithm. The oracle target the states |110> and
 // |111>. This example will also print the circuit, and show the simulaion in real time.
 //
-// This example will print s bin count of measured states from 500 repeated simulations, and the
-// superpoisition itself.
+// This example will print a bin count of measured states from 500 repeated simulations, and the
+// superposition itself.
 
 use quantr::{Circuit, Measurement, Printer, StandardGate};
 

--- a/examples/grovers.rs
+++ b/examples/grovers.rs
@@ -54,7 +54,7 @@ fn main() {
     if let Measurement::Observable(bin_count) = circuit.repeat_measurement(500).unwrap() {
         println!("[Observable] Bin count of observed states.");
         for (state, count) in bin_count {
-            println!("|{}> observed {} times", state.as_string(), count);
+            println!("|{}> observed {} times", state.to_string(), count);
         }
     }
 
@@ -63,7 +63,7 @@ fn main() {
     {
         println!("\n[Non-Observable] The amplitudes of each state in the final superposition.");
         for (state, amplitude) in output_super_position.into_iter() {
-            println!("|{}> : {}", state.as_string(), amplitude);
+            println!("|{}> : {}", state.to_string(), amplitude);
         }
     }
 }

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), QuantrError> {
 
     if let Measurement::Observable(bin_count) = qc.repeat_measurement(100).unwrap() {
         for (state, count) in bin_count {
-            println!("|{}> : {}", state.as_string(), count);
+            println!("|{}> : {}", state.to_string(), count);
         }
     }
 
@@ -43,7 +43,7 @@ fn main() -> Result<(), QuantrError> {
 
 // A QFT implementation that can be used for other circuits.
 fn qft(input_state: ProductState) -> SuperPosition {
-    let qubit_num = input_state.state.len();
+    let qubit_num = input_state.qubits.len();
     let mut mini_circuit: Circuit = Circuit::new(qubit_num).unwrap();
 
     for pos in 0..qubit_num {

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -1,11 +1,11 @@
 /*
 * Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
 * or later. You may obtain a copy of the licence at
-* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy 
-* of the EUPL-1.2 licence in English is given in LICENCE.txt which is 
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is
 * found in the root directory of this repository.
 *
-* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com> 
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
 // Uses the custom functions to define a Quantum Fourier Transform that can be applied to any
@@ -13,17 +13,19 @@
 //
 // To define the custom function, a new circuit is initialised and simulated.
 
-use quantr::{states::{ProductState, SuperPosition}, Circuit, StandardGate, Measurement, Printer};
+use quantr::{
+    states::{ProductState, SuperPosition},
+    Circuit, Measurement, Printer, QuantrError, StandardGate,
+};
 
-fn main() {
-    let mut qc: Circuit = Circuit::new(5).unwrap();
+fn main() -> Result<(), QuantrError> {
+    let mut qc: Circuit = Circuit::new(5)?;
 
-    // Apply qft 
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
-        .add_gate(StandardGate::Custom(qft, &[0, 1], "QFT".to_string()), 2).unwrap()
-        .add_gate(StandardGate::CNot(1), 3).unwrap()
-        .add_gate(StandardGate::CNot(2), 4).unwrap();
-
+    // Apply qft
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2])?
+        .add_gate(StandardGate::Custom(qft, &[0, 1], "QFT".to_string()), 2)? // QFT on bits 0, 1 and 2
+        .add_gate(StandardGate::CNot(1), 3)?
+        .add_gate(StandardGate::CNot(2), 4)?;
 
     let mut printer = Printer::new(&qc);
     printer.print_diagram();
@@ -35,16 +37,21 @@ fn main() {
             println!("|{}> : {}", state.as_string(), count);
         }
     }
+
+    Ok(())
 }
 
+// A QFT implementation that can be used for other circuits.
 fn qft(input_state: ProductState) -> SuperPosition {
     let qubit_num = input_state.state.len();
     let mut mini_circuit: Circuit = Circuit::new(qubit_num).unwrap();
 
     for pos in 0..qubit_num {
         mini_circuit.add_gate(StandardGate::H, pos).unwrap();
-        for k in 1..(qubit_num-pos) {
-            mini_circuit.add_gate(StandardGate::CRk(k as i32, k), pos).unwrap();
+        for k in 1..(qubit_num - pos) {
+            mini_circuit
+                .add_gate(StandardGate::CRk(k as i32, k), pos)
+                .unwrap();
         }
     }
 

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -1,0 +1,58 @@
+/*
+* Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
+* or later. You may obtain a copy of the licence at
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy 
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is 
+* found in the root directory of this repository.
+*
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com> 
+*/
+
+// Uses the custom functions to define a Quantum Fourier Transform that can be applied to any
+// circuit.
+//
+// To define the custom function, a new circuit is initialised and simulated.
+
+use quantr::{states::{ProductState, SuperPosition}, Circuit, StandardGate, Measurement, Printer};
+
+fn main() {
+    let mut qc: Circuit = Circuit::new(5).unwrap();
+
+    // Apply qft 
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
+        .add_gate(StandardGate::Custom(qft, &[0, 1], "QFT".to_string()), 2).unwrap()
+        .add_gate(StandardGate::CNot(1), 3).unwrap()
+        .add_gate(StandardGate::CNot(2), 4).unwrap();
+
+
+    let mut printer = Printer::new(&qc);
+    printer.print_diagram();
+
+    qc.simulate();
+
+    if let Measurement::Observable(bin_count) = qc.repeat_measurement(100).unwrap() {
+        for (state, count) in bin_count {
+            println!("|{}> : {}", state.as_string(), count);
+        }
+    }
+}
+
+fn qft(input_state: ProductState) -> SuperPosition {
+    let qubit_num = input_state.state.len();
+    let mut mini_circuit: Circuit = Circuit::new(qubit_num).unwrap();
+
+    for pos in 0..qubit_num {
+        mini_circuit.add_gate(StandardGate::H, pos).unwrap();
+        for k in 1..(qubit_num-pos) {
+            mini_circuit.add_gate(StandardGate::CRk(k as i32, k), pos).unwrap();
+        }
+    }
+
+    mini_circuit.simulate();
+
+    if let Measurement::NonObservable(super_pos) = mini_circuit.get_superposition().unwrap() {
+        super_pos.clone()
+    } else {
+        panic!("No superposition was simualted!");
+    }
+}

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -58,8 +58,9 @@ fn qft(input_state: ProductState) -> SuperPosition {
     }
 
     mini_circuit
-        .simulate_with_register(input_state.into_super_position())
-        .unwrap();
+        .change_register(input_state.into_super_position())
+        .unwrap()
+        .simulate();
 
     if let Measurement::NonObservable(super_pos) = mini_circuit.get_superposition().unwrap() {
         super_pos.clone()

--- a/examples/qft.rs
+++ b/examples/qft.rs
@@ -15,17 +15,17 @@
 
 use quantr::{
     states::{ProductState, SuperPosition},
-    Circuit, Measurement, Printer, QuantrError, StandardGate,
+    Circuit, Measurement, Printer, QuantrError, Gate,
 };
 
 fn main() -> Result<(), QuantrError> {
     let mut qc: Circuit = Circuit::new(5)?;
 
     // Apply qft
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2])?
-        .add_gate(StandardGate::Custom(qft, &[0, 1], "QFT".to_string()), 2)? // QFT on bits 0, 1 and 2
-        .add_gate(StandardGate::CNot(1), 3)?
-        .add_gate(StandardGate::CNot(2), 4)?;
+    qc.add_repeating_gate(Gate::H, &[0, 1, 2])?
+        .add_gate(Gate::Custom(qft, &[0, 1], "QFT".to_string()), 2)? // QFT on bits 0, 1 and 2
+        .add_gate(Gate::CNot(1), 3)?
+        .add_gate(Gate::CNot(2), 4)?;
 
     let mut printer = Printer::new(&qc);
     printer.print_diagram();
@@ -47,10 +47,10 @@ fn qft(input_state: ProductState) -> SuperPosition {
     let mut mini_circuit: Circuit = Circuit::new(qubit_num).unwrap();
 
     for pos in 0..qubit_num {
-        mini_circuit.add_gate(StandardGate::H, pos).unwrap();
+        mini_circuit.add_gate(Gate::H, pos).unwrap();
         for k in 1..(qubit_num - pos) {
             mini_circuit
-                .add_gate(StandardGate::CRk(k as i32, k), pos)
+                .add_gate(Gate::CRk(k as i32, k), pos)
                 .unwrap();
         }
     }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -1,11 +1,11 @@
 /*
 * Copyright (c) 2023 Andrew Rowan Barlow. Licensed under the EUPL-1.2
 * or later. You may obtain a copy of the licence at
-* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy
-* of the EUPL-1.2 licence in English is given in LICENCE.txt which is
+* https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12. A copy 
+* of the EUPL-1.2 licence in English is given in LICENCE.txt which is 
 * found in the root directory of this repository.
 *
-* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
+* Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com> 
 */
 
 //! Construct, simulate and measure quantum circuits.
@@ -411,6 +411,7 @@ impl<'a> Circuit<'a> {
         }
     }
 
+    // need to implement all other gates, in addition to checking that it's within circuit size!
     fn has_overlapping_controls_and_target(gates: &[StandardGate]) -> Result<(), QuantrError> {
         for (pos, gate) in gates.iter().enumerate() {
             match *gate {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -195,7 +195,6 @@ struct GateInfo<'a> {
     size: GateSize,
 }
 
-
 /// A quantum circuit where gates can be appended and then simulated to measure resulting
 /// superpositions.
 pub struct Circuit<'a> {
@@ -255,7 +254,11 @@ impl<'a> Circuit<'a> {
     /// // -------
     /// // -------
     /// ```
-    pub fn add_gate(&mut self, gate: StandardGate<'a>, position: usize) -> Result<&mut Circuit<'a>, QuantrError> {
+    pub fn add_gate(
+        &mut self,
+        gate: StandardGate<'a>,
+        position: usize,
+    ) -> Result<&mut Circuit<'a>, QuantrError> {
         Self::add_gates_with_positions(self, HashMap::from([(position, gate)]))
     }
 
@@ -341,7 +344,10 @@ impl<'a> Circuit<'a> {
     /// // -- X --
     /// // -- Y --
     /// ```
-    pub fn add_gates(&mut self, gates: &[StandardGate<'a>]) -> Result<&mut Circuit<'a>, QuantrError> {
+    pub fn add_gates(
+        &mut self,
+        gates: &[StandardGate<'a>],
+    ) -> Result<&mut Circuit<'a>, QuantrError> {
         // Ensured we have a gate for every wire.
         if gates.len() != self.num_qubits {
             return Err(QuantrError {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -23,13 +23,13 @@
 //! [Circuit::repeat_measurement], where a new register is attached before each measurment. Or, the
 //! explicit superpositon can be retreived using [Circuit::get_superposition].
 
-use crate::complex::Complex;
+use crate::Complex;
 use core::panic;
 use rand::Rng;
 use std::collections::HashMap;
 use std::ops::{Add, Mul};
 
-use crate::circuit::states::{ProductState, Qubit, SuperPosition};
+use crate::states::{ProductState, Qubit, SuperPosition};
 use crate::QuantrError;
 
 pub mod printer;
@@ -117,10 +117,9 @@ pub enum StandardGate<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
-    /// use quantr::circuit::states::{SuperPosition, ProductState, Qubit};
-    /// use quantr::complex::Complex;
-    /// use quantr::complex_Re_array;
+    /// use quantr::{Circuit, StandardGate};
+    /// use quantr::states::{SuperPosition, ProductState, Qubit};
+    /// use quantr::{Complex, complex_Re_array};
     ///
     /// // Defines a C-Not gate
     /// fn example_cnot(prod: ProductState) -> SuperPosition {
@@ -213,7 +212,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::Circuit;
+    /// use quantr::Circuit;
     ///
     /// // Initialises a 3 qubit circuit.
     /// let quantum_circuit: Circuit = Circuit::new(3).unwrap();
@@ -245,7 +244,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     ///
     /// let mut quantum_circuit: Circuit = Circuit::new(3).unwrap();
     /// quantum_circuit.add_gate(StandardGate::X, 0).unwrap();
@@ -267,7 +266,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     /// use std::collections::HashMap;
     ///
     /// let mut quantum_circuit: Circuit = Circuit::new(3).unwrap();
@@ -329,7 +328,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example   
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     ///
     /// let mut quantum_circuit: Circuit = Circuit::new(3).unwrap();
     /// let gates_to_add: Vec<StandardGate> = vec![StandardGate::H, StandardGate::X, StandardGate::Y];
@@ -452,7 +451,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     ///
     /// let mut quantum_circuit: Circuit = Circuit::new(3).unwrap();
     /// quantum_circuit.add_repeating_gate(StandardGate::H, vec![1, 2]).unwrap();
@@ -501,7 +500,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{states::SuperPosition, Circuit, Measurement::NonObservable, StandardGate};
+    /// use quantr::{states::SuperPosition, Circuit, Measurement::NonObservable, StandardGate};
     ///
     /// let mut circuit = Circuit::new(3).unwrap();
     ///
@@ -541,7 +540,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{states::SuperPosition, Circuit, Measurement::Observable, StandardGate};
+    /// use quantr::{states::SuperPosition, Circuit, Measurement::Observable, StandardGate};
     ///
     /// let mut circuit = Circuit::new(3).unwrap();
     ///
@@ -606,7 +605,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     ///
     /// let mut circuit = Circuit::new(3).unwrap();
     /// circuit.add_gate(StandardGate::H, 2).unwrap();
@@ -663,8 +662,8 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
-    /// use quantr::circuit::states::{Qubit, ProductState, SuperPosition};
+    /// use quantr::{Circuit, StandardGate};
+    /// use quantr::states::{Qubit, ProductState, SuperPosition};
     ///
     /// let mut circuit = Circuit::new(2).unwrap();
     /// circuit.add_gate(StandardGate::X, 1).unwrap();
@@ -987,7 +986,7 @@ impl<'a> Circuit<'a> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate};
+    /// use quantr::{Circuit, StandardGate};
     ///
     /// let mut circuit = Circuit::new(3).unwrap();
     /// circuit.add_gate(StandardGate::H, 2).unwrap();
@@ -1006,7 +1005,7 @@ impl<'a> Circuit<'a> {
 mod tests {
     use crate::{complex_Im, complex_Re, complex_Re_array, complex_zero, complex};
     use std::f64::consts::{FRAC_1_SQRT_2, PI};
-    use crate::circuit::Measurement::NonObservable;
+    use crate::Measurement::NonObservable;
     use super::*;
     const ERROR_MARGIN: f64 = 0.000001f64; // For comparing floats due to floating point error.
     // Needed for testing

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -448,16 +448,12 @@ mod tests {
     #[test]
     fn producing_string_circuit() {
         let mut quantum_circuit = Circuit::new(4).unwrap();
-        quantum_circuit.add_gate(StandardGate::H, 3).unwrap();
-        quantum_circuit
-            .add_repeating_gate(StandardGate::Y, vec![0, 1])
-            .unwrap();
-        quantum_circuit
-            .add_gate(StandardGate::Toffoli(0, 3), 1)
-            .unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(1), 3).unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(2), 0).unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(2), 1).unwrap();
+        quantum_circuit.add_gate(StandardGate::H, 3).unwrap()
+            .add_repeating_gate(StandardGate::Y, &[0, 1]).unwrap()
+            .add_gate(StandardGate::Toffoli(0, 3), 1).unwrap()
+            .add_gate(StandardGate::CNot(1), 3).unwrap()
+            .add_gate(StandardGate::CNot(2), 0).unwrap()
+            .add_gate(StandardGate::CNot(2), 1).unwrap();
 
         let mut circuit_printer: Printer = Printer::new(&quantum_circuit);
 
@@ -471,22 +467,20 @@ mod tests {
         let mut quantum_circuit = Circuit::new(4).unwrap();
         quantum_circuit.add_gate(StandardGate::H, 3).unwrap();
         quantum_circuit
-            .add_gates(vec![
+            .add_gates(&[
                 StandardGate::H,
                 StandardGate::Custom(example_cnot, &[3], "Custom CNot".to_string()),
                 StandardGate::Id,
                 StandardGate::X,
             ])
-            .unwrap();
-        quantum_circuit
-            .add_repeating_gate(StandardGate::Y, vec![0, 1])
-            .unwrap();
-        quantum_circuit
+            .unwrap()
+            .add_repeating_gate(StandardGate::Y, &[0, 1])
+            .unwrap()
             .add_gate(StandardGate::Toffoli(0, 3), 1)
-            .unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(1), 3).unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(2), 0).unwrap();
-        quantum_circuit.add_gate(StandardGate::CNot(2), 1).unwrap();
+            .unwrap()
+            .add_gate(StandardGate::CNot(1), 3).unwrap()
+            .add_gate(StandardGate::CNot(2), 0).unwrap()
+            .add_gate(StandardGate::CNot(2), 1).unwrap();
 
         let mut circuit_printer: Printer = Printer::new(&quantum_circuit);
 

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -435,7 +435,7 @@ mod tests {
     // the terminal, and then copy the output for the assert_eq! macro.
 
     fn example_cnot(prod: ProductState) -> SuperPosition {
-        let input_register: [Qubit; 2] = [prod.state[0], prod.state[1]];
+        let input_register: [Qubit; 2] = [prod.qubits[0], prod.qubits[1]];
         SuperPosition::new(2)
             .set_amplitudes(match input_register {
                 [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -72,7 +72,7 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate, printer::Printer};
+    /// use quantr::{Circuit, StandardGate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
     /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
@@ -101,7 +101,7 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate, printer::Printer};
+    /// use quantr::{Circuit, StandardGate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
     /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
@@ -123,7 +123,7 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate, printer::Printer};
+    /// use quantr::{Circuit, StandardGate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
     /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
@@ -147,7 +147,7 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::{Circuit, StandardGate, printer::Printer};
+    /// use quantr::{Circuit, StandardGate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
     /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
@@ -425,10 +425,10 @@ impl Printer<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::circuit::{
-        printer::Printer, Circuit, ProductState, Qubit, StandardGate, SuperPosition,
+    use crate::{
+        Printer, Circuit, StandardGate, states::{Qubit, ProductState, SuperPosition},
     };
-    use crate::complex::Complex;
+    use crate::Complex;
     use crate::complex_Re_array;
     // These are primarily tested by making sure they print correctly to
     // the terminal, and then copy the output for the assert_eq! macro.

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -423,6 +423,7 @@ impl Printer<'_> {
     }
 }
 
+#[rustfmt::skip]
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -472,12 +473,9 @@ mod tests {
                 StandardGate::Custom(example_cnot, &[3], "Custom CNot".to_string()),
                 StandardGate::Id,
                 StandardGate::X,
-            ])
-            .unwrap()
-            .add_repeating_gate(StandardGate::Y, &[0, 1])
-            .unwrap()
-            .add_gate(StandardGate::Toffoli(0, 3), 1)
-            .unwrap()
+            ]).unwrap()
+            .add_repeating_gate(StandardGate::Y, &[0, 1]).unwrap()
+            .add_gate(StandardGate::Toffoli(0, 3), 1).unwrap()
             .add_gate(StandardGate::CNot(1), 3).unwrap()
             .add_gate(StandardGate::CNot(2), 0).unwrap()
             .add_gate(StandardGate::CNot(2), 1).unwrap();

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -12,11 +12,9 @@
 //!
 //! The user has the option to print the string to the terminal or a text file, where the text file
 //! has the advantage of not wrapping the circuit within the terminal. The [Printer] will also
-//! cache a copy of the diagram so subsequent prints will require no building of the diagram. This
-//! cache can be removed with [Printer::flush] to force the [Printer] to construct the circuit
-//! diagram again.
+//! cache a copy of the diagram so subsequent prints will require no building of the diagram.
 
-use super::{Circuit, GateSize, Gate};
+use super::{Circuit, Gate, GateSize};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -159,18 +157,6 @@ impl Printer<'_> {
         self.get_or_make_diagram()
     }
 
-    /// Will be depreceated as it cannot be used due to lifetime borrowing, and the quantum circuit
-    /// needs to be mutable.
-    ///
-    /// Removes the cache of the circuit diagram.
-    ///
-    /// Future calls to print the diagram will have to build the diagram from scratch. Can be used
-    /// if the circuit has been updated, and the printer needs to rebuild the diagram.
-    #[deprecated]
-    pub fn flush(&mut self) {
-        self.diagram = None;
-    }
-
     // Constructs the diagram, or returns the diagram previously built.
     fn get_or_make_diagram(&mut self) -> String {
         match &self.diagram {
@@ -250,6 +236,7 @@ impl Printer<'_> {
 
     fn get_gate_name(gate: &Gate) -> String {
         match gate {
+            Gate::Id => "".to_string(),
             Gate::X => "X".to_string(),
             Gate::H => "H".to_string(),
             Gate::S => "S".to_string(),
@@ -274,7 +261,6 @@ impl Printer<'_> {
             Gate::CNot(_) => "X".to_string(),
             Gate::Toffoli(_, _) => "X".to_string(),
             Gate::Custom(_, _, name) => name.to_string(),
-            _ => String::from("#"),
         }
     }
 

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -16,7 +16,7 @@
 //! cache can be removed with [Printer::flush] to force the [Printer] to construct the circuit
 //! diagram again.
 
-use super::{Circuit, GateSize, StandardGate};
+use super::{Circuit, GateSize, Gate};
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -48,7 +48,7 @@ struct GatePrinterInfo<'a> {
     gate_size: GateSize,
     gate_name: String,
     gate_name_length: usize,
-    gate: &'a StandardGate<'a>,
+    gate: &'a Gate<'a>,
 }
 
 #[derive(Debug)]
@@ -72,10 +72,10 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::{Circuit, StandardGate, Printer};
+    /// use quantr::{Circuit, Gate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
-    /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
+    /// qc.add_gate(Gate::CNot(0), 1).unwrap();
     ///
     /// let mut printer: Printer = Printer::new(&qc);
     /// printer.print_diagram();
@@ -101,10 +101,10 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::{Circuit, StandardGate, Printer};
+    /// use quantr::{Circuit, Gate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
-    /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
+    /// qc.add_gate(Gate::CNot(0), 1).unwrap();
     ///
     /// let mut printer: Printer = Printer::new(&qc);
     /// // printer.save_diagram("diagram.txt").unwrap();
@@ -123,10 +123,10 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::{Circuit, StandardGate, Printer};
+    /// use quantr::{Circuit, Gate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
-    /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
+    /// qc.add_gate(Gate::CNot(0), 1).unwrap();
     ///
     /// let mut printer: Printer = Printer::new(&qc);
     /// // printer.print_and_save_diagram("diagram.txt").unwrap();
@@ -147,10 +147,10 @@ impl Printer<'_> {
     ///
     /// # Example
     /// ```
-    /// use quantr::{Circuit, StandardGate, Printer};
+    /// use quantr::{Circuit, Gate, Printer};
     ///
     /// let mut qc: Circuit = Circuit::new(2).unwrap();
-    /// qc.add_gate(StandardGate::CNot(0), 1).unwrap();
+    /// qc.add_gate(Gate::CNot(0), 1).unwrap();
     ///
     /// let mut printer: Printer = Printer::new(&qc);
     /// println!("{}", printer.get_diagram()); // equivalent to Printer::print_diagram
@@ -221,13 +221,13 @@ impl Printer<'_> {
         final_diagram
     }
 
-    fn get_column_of_gates(&self, column_num: usize) -> &[StandardGate] {
+    fn get_column_of_gates(&self, column_num: usize) -> &[Gate] {
         &self.circuit.circuit_gates
             [column_num * self.circuit.num_qubits..(column_num + 1) * self.circuit.num_qubits]
     }
 
     fn into_printer_gate_info<'a>(
-        gates_column: &'a [StandardGate<'a>],
+        gates_column: &'a [Gate<'a>],
     ) -> (Vec<GatePrinterInfo<'a>>, usize) {
         let mut gates_infos: Vec<GatePrinterInfo> = Default::default();
         let mut longest_name_length: usize = 1usize;
@@ -248,32 +248,32 @@ impl Printer<'_> {
         (gates_infos, longest_name_length)
     }
 
-    fn get_gate_name(gate: &StandardGate) -> String {
+    fn get_gate_name(gate: &Gate) -> String {
         match gate {
-            StandardGate::X => "X".to_string(),
-            StandardGate::H => "H".to_string(),
-            StandardGate::S => "S".to_string(),
-            StandardGate::Sdag => "S*".to_string(),
-            StandardGate::T => "T".to_string(),
-            StandardGate::Tdag => "T*".to_string(),
-            StandardGate::Y => "Y".to_string(),
-            StandardGate::Z => "Z".to_string(),
-            StandardGate::Rx(_) => "Rx".to_string(),
-            StandardGate::Ry(_) => "Ry".to_string(),
-            StandardGate::Rz(_) => "Rz".to_string(),
-            StandardGate::Phase(_) => "P".to_string(),
-            StandardGate::X90 => "X90".to_string(),
-            StandardGate::Y90 => "Y90".to_string(),
-            StandardGate::MX90 => "X90*".to_string(),
-            StandardGate::MY90 => "Y90*".to_string(),
-            StandardGate::CR(_, _) => "CR".to_string(),
-            StandardGate::CRk(_, _) => "CRk".to_string(),
-            StandardGate::Swap(_) => "Sw".to_string(),
-            StandardGate::CZ(_) => "Z".to_string(),
-            StandardGate::CY(_) => "Y".to_string(),
-            StandardGate::CNot(_) => "X".to_string(),
-            StandardGate::Toffoli(_, _) => "X".to_string(),
-            StandardGate::Custom(_, _, name) => name.to_string(),
+            Gate::X => "X".to_string(),
+            Gate::H => "H".to_string(),
+            Gate::S => "S".to_string(),
+            Gate::Sdag => "S*".to_string(),
+            Gate::T => "T".to_string(),
+            Gate::Tdag => "T*".to_string(),
+            Gate::Y => "Y".to_string(),
+            Gate::Z => "Z".to_string(),
+            Gate::Rx(_) => "Rx".to_string(),
+            Gate::Ry(_) => "Ry".to_string(),
+            Gate::Rz(_) => "Rz".to_string(),
+            Gate::Phase(_) => "P".to_string(),
+            Gate::X90 => "X90".to_string(),
+            Gate::Y90 => "Y90".to_string(),
+            Gate::MX90 => "X90*".to_string(),
+            Gate::MY90 => "Y90*".to_string(),
+            Gate::CR(_, _) => "CR".to_string(),
+            Gate::CRk(_, _) => "CRk".to_string(),
+            Gate::Swap(_) => "Sw".to_string(),
+            Gate::CZ(_) => "Z".to_string(),
+            Gate::CY(_) => "Y".to_string(),
+            Gate::CNot(_) => "X".to_string(),
+            Gate::Toffoli(_, _) => "X".to_string(),
+            Gate::Custom(_, _, name) => name.to_string(),
             _ => String::from("#"),
         }
     }
@@ -296,7 +296,7 @@ impl Printer<'_> {
         for (pos, gate_info) in diagram_scheme.gate_info_column.iter().enumerate() {
             let padding: usize = diagram_scheme.longest_name_length - gate_info.gate_name_length;
             let cache: RowSchematic = match gate_info.gate {
-                StandardGate::Id => RowSchematic {
+                Gate::Id => RowSchematic {
                     top: " ".repeat(diagram_scheme.longest_name_length + 4),
                     name: "─".repeat(diagram_scheme.longest_name_length + 4),
                     bottom: " ".repeat(diagram_scheme.longest_name_length + 4),
@@ -427,7 +427,7 @@ impl Printer<'_> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Printer, Circuit, StandardGate, states::{Qubit, ProductState, SuperPosition},
+        Printer, Circuit, Gate, states::{Qubit, ProductState, SuperPosition},
     };
     use crate::Complex;
     use crate::complex_Re_array;
@@ -449,12 +449,12 @@ mod tests {
     #[test]
     fn producing_string_circuit() {
         let mut quantum_circuit = Circuit::new(4).unwrap();
-        quantum_circuit.add_gate(StandardGate::H, 3).unwrap()
-            .add_repeating_gate(StandardGate::Y, &[0, 1]).unwrap()
-            .add_gate(StandardGate::Toffoli(0, 3), 1).unwrap()
-            .add_gate(StandardGate::CNot(1), 3).unwrap()
-            .add_gate(StandardGate::CNot(2), 0).unwrap()
-            .add_gate(StandardGate::CNot(2), 1).unwrap();
+        quantum_circuit.add_gate(Gate::H, 3).unwrap()
+            .add_repeating_gate(Gate::Y, &[0, 1]).unwrap()
+            .add_gate(Gate::Toffoli(0, 3), 1).unwrap()
+            .add_gate(Gate::CNot(1), 3).unwrap()
+            .add_gate(Gate::CNot(2), 0).unwrap()
+            .add_gate(Gate::CNot(2), 1).unwrap();
 
         let mut circuit_printer: Printer = Printer::new(&quantum_circuit);
 
@@ -466,19 +466,19 @@ mod tests {
     #[test]
     fn producing_string_circuit_custom() {
         let mut quantum_circuit = Circuit::new(4).unwrap();
-        quantum_circuit.add_gate(StandardGate::H, 3).unwrap();
+        quantum_circuit.add_gate(Gate::H, 3).unwrap();
         quantum_circuit
             .add_gates(&[
-                StandardGate::H,
-                StandardGate::Custom(example_cnot, &[3], "Custom CNot".to_string()),
-                StandardGate::Id,
-                StandardGate::X,
+                Gate::H,
+                Gate::Custom(example_cnot, &[3], "Custom CNot".to_string()),
+                Gate::Id,
+                Gate::X,
             ]).unwrap()
-            .add_repeating_gate(StandardGate::Y, &[0, 1]).unwrap()
-            .add_gate(StandardGate::Toffoli(0, 3), 1).unwrap()
-            .add_gate(StandardGate::CNot(1), 3).unwrap()
-            .add_gate(StandardGate::CNot(2), 0).unwrap()
-            .add_gate(StandardGate::CNot(2), 1).unwrap();
+            .add_repeating_gate(Gate::Y, &[0, 1]).unwrap()
+            .add_gate(Gate::Toffoli(0, 3), 1).unwrap()
+            .add_gate(Gate::CNot(1), 3).unwrap()
+            .add_gate(Gate::CNot(2), 0).unwrap()
+            .add_gate(Gate::CNot(2), 1).unwrap();
 
         let mut circuit_printer: Printer = Printer::new(&quantum_circuit);
 

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -13,8 +13,8 @@
 //! These linear functions are defined by how they act on product states of qubits. Defining the
 //! mappings on a basis defines how the gates act on larger product spaces.
 
-use crate::circuit::states::{ProductState, Qubit, SuperPosition};
-use crate::complex::Complex;
+use crate::states::{ProductState, Qubit, SuperPosition};
+use crate::Complex;
 use crate::{complex, complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero};
 use std::f64::consts::FRAC_1_SQRT_2;
 use std::ops::{Div, Mul};

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -15,7 +15,7 @@
 
 use crate::states::{ProductState, Qubit, SuperPosition};
 use crate::Complex;
-use crate::{complex, complex_Im, complex_Im_array, complex_Re, complex_Re_array, complex_zero};
+use crate::{complex, complex_Im, complex_Im_array, complex_Re, complex_Re_array, COMPLEX_ZERO};
 use std::f64::consts::FRAC_1_SQRT_2;
 use std::ops::{Div, Mul};
 
@@ -36,8 +36,8 @@ use std::ops::{Div, Mul};
 #[rustfmt::skip]
 pub fn identity(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex_Re!(1f64)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex_Re!(1f64)],
     }).unwrap()
 }
 
@@ -78,10 +78,10 @@ pub fn ry(register: Qubit, angle: f64) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn rz(register: Qubit, angle: f64) -> SuperPosition {
-    let neg_exp: Complex<f64> = Complex::<f64>::expi(-angle*0.5f64);
-    let pos_exp: Complex<f64> = Complex::<f64>::expi(angle*0.5f64);
-    let zero_map: [Complex<f64>; 2] = [neg_exp, complex_zero!()];
-    let one_map: [Complex<f64>; 2] = [complex_zero!(), pos_exp];
+    let neg_exp: Complex<f64> = Complex::<f64>::exp_im(-angle*0.5f64);
+    let pos_exp: Complex<f64> = Complex::<f64>::exp_im(angle*0.5f64);
+    let zero_map: [Complex<f64>; 2] = [neg_exp, COMPLEX_ZERO];
+    let one_map: [Complex<f64>; 2] = [COMPLEX_ZERO, pos_exp];
 
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
@@ -91,9 +91,9 @@ pub fn rz(register: Qubit, angle: f64) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn global_phase(register: Qubit, angle: f64) -> SuperPosition {
-    let exp: Complex<f64> = Complex::<f64>::expi(angle*0.5f64);
-    let zero_map: [Complex<f64>; 2] = [exp, complex_zero!()];
-    let one_map: [Complex<f64>; 2] = [complex_zero!(), exp];
+    let exp: Complex<f64> = Complex::<f64>::exp_im(angle*0.5f64);
+    let zero_map: [Complex<f64>; 2] = [exp, COMPLEX_ZERO];
+    let one_map: [Complex<f64>; 2] = [COMPLEX_ZERO, exp];
 
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
         Qubit::Zero => &zero_map,
@@ -104,88 +104,88 @@ pub fn global_phase(register: Qubit, angle: f64) -> SuperPosition {
 #[rustfmt::skip]
 pub fn x90(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Im!(-1f64)],
-        Qubit::One => &[complex_Im!(-1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Im!(-1f64)],
+        Qubit::One => &[complex_Im!(-1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn y90(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Re!(-1f64)],
-        Qubit::One => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Re!(-1f64)],
+        Qubit::One => &[complex_Re!(1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn mx90(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Im!(1f64)],
-        Qubit::One => &[complex_Im!(1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Im!(1f64)],
+        Qubit::One => &[complex_Im!(1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn my90(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Re!(1f64)],
-        Qubit::One => &[complex_Re!(-1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Re!(1f64)],
+        Qubit::One => &[complex_Re!(-1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn tgate(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, FRAC_1_SQRT_2)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex!(FRAC_1_SQRT_2, FRAC_1_SQRT_2)],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn tgatedag(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex!(FRAC_1_SQRT_2, -FRAC_1_SQRT_2)],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn phase(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex_Im!(1f64)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex_Im!(1f64)],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn phasedag(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex_Im!(-1f64)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex_Im!(-1f64)],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn pauli_x(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Re!(1f64)],
-        Qubit::One => &[complex_Re!(1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Re!(1f64)],
+        Qubit::One => &[complex_Re!(1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn pauli_y(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_zero!(), complex_Im!(1f64)],
-        Qubit::One => &[complex_Im!(-1f64), complex_zero!()],
+        Qubit::Zero => &[COMPLEX_ZERO, complex_Im!(1f64)],
+        Qubit::One => &[complex_Im!(-1f64), COMPLEX_ZERO],
     }).unwrap()
 }
 
 #[rustfmt::skip]
 pub fn pauli_z(register: Qubit) -> SuperPosition {
     SuperPosition::new(1).set_amplitudes_unchecked(match register {
-        Qubit::Zero => &[complex_Re!(1f64), complex_zero!()],
-        Qubit::One => &[complex_zero!(), complex_Re!(-1f64)],
+        Qubit::Zero => &[complex_Re!(1f64), COMPLEX_ZERO],
+        Qubit::One => &[COMPLEX_ZERO, complex_Re!(-1f64)],
     }).unwrap()
 }
 
@@ -195,7 +195,7 @@ pub fn pauli_z(register: Qubit) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn cnot(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -206,7 +206,7 @@ pub fn cnot(register: ProductState) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn cy(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -217,7 +217,7 @@ pub fn cy(register: ProductState) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn cz(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -228,7 +228,7 @@ pub fn cz(register: ProductState) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn swap(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 0f64, 1f64, 0f64),
@@ -239,8 +239,8 @@ pub fn swap(register: ProductState) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn cr(register: ProductState, angle: f64) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
-    let exp_array: [Complex<f64>; 4] = [complex_zero!(), complex_zero!(), complex_zero!(), Complex::<f64>::expi(angle)];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
+    let exp_array: [Complex<f64>; 4] = [COMPLEX_ZERO, COMPLEX_ZERO, COMPLEX_ZERO, Complex::<f64>::exp_im(angle)];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -251,9 +251,9 @@ pub fn cr(register: ProductState, angle: f64) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn crk(register: ProductState, k: i32) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.state[0], register.state[1]];
+    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
     let exp_array: [Complex<f64>; 4] = 
-        [complex_zero!(), complex_zero!(), complex_zero!(), Complex::<f64>::expi((2f64*std::f64::consts::PI).div(2f64.powi(k)))];
+        [COMPLEX_ZERO, COMPLEX_ZERO, COMPLEX_ZERO, Complex::<f64>::exp_im((2f64*std::f64::consts::PI).div(2f64.powi(k)))];
     SuperPosition::new(2).set_amplitudes_unchecked(match input_register {
         [Qubit::Zero, Qubit::Zero] => &complex_Re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => &complex_Re_array!(0f64, 1f64, 0f64, 0f64),
@@ -268,7 +268,7 @@ pub fn crk(register: ProductState, k: i32) -> SuperPosition {
 
 #[rustfmt::skip]
 pub fn toffoli(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 3] = [register.state[0], register.state[1], register.state[2]];
+    let input_register: [Qubit; 3] = [register.qubits[0], register.qubits[1], register.qubits[2]];
     SuperPosition::new(3)
         .set_amplitudes_unchecked(match input_register {
             [Qubit::Zero, Qubit::Zero, Qubit::Zero] => {&complex_Re_array!(1f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64) }

--- a/src/circuit/states.rs
+++ b/src/circuit/states.rs
@@ -19,7 +19,7 @@
 //!  ⋮    ⋮
 //!  ```
 
-use crate::complex::Complex;
+use crate::Complex;
 use crate::QuantrError;
 use crate::{complex_Re, complex_zero};
 use std::collections::HashMap;
@@ -40,7 +40,7 @@ impl Qubit {
     ///
     /// # Example
     /// ```
-    /// use quantr::circuit::states::{ProductState, Qubit};
+    /// use quantr::states::{ProductState, Qubit};
     ///
     /// let qubit_a: Qubit = Qubit::Zero; // |0>
     /// let qubit_b: Qubit = Qubit::One;  // |1>
@@ -200,8 +200,8 @@ pub struct SuperPosition {
 ///
 /// # Example
 /// ```
-/// use quantr::circuit::states::{ProductState, Qubit, SuperPosition};
-/// use quantr::{complex_Re, complex_Re_vec, complex_zero, complex::Complex};
+/// use quantr::states::{ProductState, Qubit, SuperPosition};
+/// use quantr::{complex_Re, complex_Re_vec, complex_zero, Complex};
 /// use std::f64::consts::FRAC_1_SQRT_2;
 ///
 /// let super_pos: SuperPosition = SuperPosition::new(2)

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -18,6 +18,8 @@ use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Add, Mul, Sub};
 
+pub const COMPLEX_ZERO: Complex<f64> = Complex::<f64> { re: 0f64, im: 0f64 };
+
 /// A square root trait, that is only implemented for `f32` and `f64` as Sqrt is not a closed
 /// operation for int, uint, etc. This is needed for the absolute value of a complex number.
 pub trait Sqr {
@@ -39,8 +41,8 @@ impl Sqr for f64 {
 /// Generic complex number for the quantum computer. Will mostly use `f64`.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Complex<T> {
-    pub real: T,
-    pub imaginary: T,
+    pub re: T,
+    pub im: T,
 }
 
 impl Complex<f64> {
@@ -52,12 +54,12 @@ impl Complex<f64> {
     /// use quantr::complex_Im;
     /// use std::f64::consts::PI;
     ///
-    /// let num: Complex<f64> = Complex::<f64>::expi(0.5f64 * PI);
+    /// let num: Complex<f64> = Complex::<f64>::exp_im(0.5f64 * PI);
     /// ```
-    pub fn expi(theta: f64) -> Complex<f64> {
+    pub fn exp_im(theta: f64) -> Complex<f64> {
         Complex {
-            real: theta.cos(),
-            imaginary: theta.sin(),
+            re: theta.cos(),
+            im: theta.sin(),
         }
     }
 }
@@ -71,13 +73,13 @@ impl Complex<f32> {
     /// use quantr::complex_Im;
     /// use std::f32::consts::PI;
     ///
-    /// let num: Complex<f32> = Complex::<f32>::expi(0.5f32 * PI);
+    /// let num: Complex<f32> = Complex::<f32>::exp_im(0.5f32 * PI);
     /// ```
 
-    pub fn expi(theta: f32) -> Complex<f32> {
+    pub fn exp_im(theta: f32) -> Complex<f32> {
         Complex {
-            real: theta.cos(),
-            imaginary: theta.sin(),
+            re: theta.cos(),
+            im: theta.sin(),
         }
     }
 }
@@ -88,8 +90,8 @@ impl<T: Add<Output = T>> Add for Complex<T> {
 
     fn add(self, rhs: Self) -> Self::Output {
         Complex {
-            real: self.real.add(rhs.real),
-            imaginary: self.imaginary.add(rhs.imaginary),
+            re: self.re.add(rhs.re),
+            im: self.im.add(rhs.im),
         }
     }
 }
@@ -100,8 +102,8 @@ impl<T: Sub<Output = T>> Sub for Complex<T> {
 
     fn sub(self, rhs: Self) -> Self::Output {
         Complex {
-            real: self.real.sub(rhs.real),
-            imaginary: self.imaginary.sub(rhs.imaginary),
+            re: self.re.sub(rhs.re),
+            im: self.im.sub(rhs.im),
         }
     }
 }
@@ -112,14 +114,8 @@ impl<T: Mul<Output = T> + Add<Output = T> + Sub<Output = T> + Copy> Mul for Comp
 
     fn mul(self, rhs: Self) -> Self::Output {
         Complex {
-            real: self
-                .real
-                .mul(rhs.real)
-                .sub(self.imaginary.mul(rhs.imaginary)),
-            imaginary: self
-                .real
-                .mul(rhs.imaginary)
-                .add(self.imaginary.mul(rhs.real)),
+            re: self.re.mul(rhs.re).sub(self.im.mul(rhs.im)),
+            im: self.re.mul(rhs.im).add(self.im.mul(rhs.re)),
         }
     }
 }
@@ -130,8 +126,8 @@ impl Mul<f64> for Complex<f64> {
 
     fn mul(self, rhs: f64) -> Self::Output {
         Complex {
-            real: self.real.mul(rhs),
-            imaginary: self.imaginary.mul(rhs),
+            re: self.re.mul(rhs),
+            im: self.im.mul(rhs),
         }
     }
 }
@@ -142,8 +138,8 @@ impl Mul<Complex<f64>> for f64 {
 
     fn mul(self, rhs: Complex<f64>) -> Self::Output {
         Complex {
-            real: rhs.real.mul(self),
-            imaginary: rhs.imaginary.mul(self),
+            re: rhs.re.mul(self),
+            im: rhs.im.mul(self),
         }
     }
 }
@@ -152,9 +148,7 @@ impl<T: Add<Output = T> + Mul<Output = T> + Copy> Complex<T> {
     /// Absolute square of a complex number, that is `|z|^2 = a^2+b^2`
     /// where `z = a + bi`.
     pub fn abs_square(self) -> T {
-        self.real
-            .mul(self.real)
-            .add(self.imaginary.mul(self.imaginary))
+        self.re.mul(self.re).add(self.im.mul(self.im))
     }
 }
 
@@ -168,30 +162,16 @@ impl<T: Add<Output = T> + Mul<Output = T> + Sqr + Copy> Complex<T> {
 
 impl<T: fmt::Display> fmt::Display for Complex<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{} + {}i", self.real, self.imaginary)
+        write!(f, "{} + {}i", self.re, self.im)
     }
 }
 
-/// Shortcut for `complex!(0f64, 0f64)`.
-#[macro_export]
-macro_rules! complex_zero {
-    () => {
-        Complex::<f64> {
-            real: 0f64,
-            imaginary: 0f64,
-        }
-    };
-}
-
-/// Usage: `complex!(real: f64, imaginary: f64) -> Complex<f64>`
+/// Usage: `complex!(re: f64, im: f64) -> Complex<f64>`
 /// A quick way to define a f64 complex number.
 #[macro_export]
 macro_rules! complex {
     ($r:expr, $i:expr) => {
-        Complex::<f64> {
-            real: $r,
-            imaginary: $i,
-        }
+        Complex::<f64> { re: $r, im: $i }
     };
 }
 
@@ -203,8 +183,8 @@ macro_rules! complex_Re_array {
         [
         $(
             Complex::<f64> {
-                real: $x,
-                imaginary: 0f64
+                re: $x,
+                im: 0f64
             }
         ),*
         ]
@@ -219,8 +199,8 @@ macro_rules! complex_Im_array {
         [
         $(
             Complex::<f64> {
-                real: 0f64,
-                imaginary: $x
+                re: 0f64,
+                im: $x
             }
         ),*
         ]
@@ -237,8 +217,8 @@ macro_rules! complex_Re_vec {
             $(
                 temp_vec.push(
                     Complex::<f64> {
-                        real: $x,
-                        imaginary: 0f64
+                        re: $x,
+                        im: 0f64
                     }
                 );
             )*
@@ -257,8 +237,8 @@ macro_rules! complex_Im_vec {
             $(
                 temp_vec.push(
                     Complex::<f64> {
-                        real: 0f64,
-                        imaginary: $x,
+                        re: 0f64,
+                        im: $x,
                     }
                 );
             )*
@@ -267,27 +247,21 @@ macro_rules! complex_Im_vec {
     };
 }
 
-/// Usage: `complex_Re!(real: f64) -> Complex<f64>`
+/// Usage: `complex_Re!(re: f64) -> Complex<f64>`
 /// A quick way to define a real f64; the imaginary part is set to zero.
 #[macro_export]
 macro_rules! complex_Re {
     ($r:expr) => {
-        Complex::<f64> {
-            real: $r,
-            imaginary: 0f64,
-        }
+        Complex::<f64> { re: $r, im: 0f64 }
     };
 }
 
-/// Usage: `complex_Im!(imaginary: f64) -> Complex<f64>`
+/// Usage: `complex_Im!(im: f64) -> Complex<f64>`
 /// A quick way to define an imaginary f64; the real part is set to zero.
 #[macro_export]
 macro_rules! complex_Im {
     ($i:expr) => {
-        Complex::<f64> {
-            real: 0f64,
-            imaginary: $i,
-        }
+        Complex::<f64> { re: 0f64, im: $i }
     };
 }
 
@@ -298,69 +272,69 @@ mod tests {
 
     #[test]
     fn complex_imaginary_and_imaginary() {
-        let num_one = Complex::<i8>{real: 0, imaginary: 9};
-        let num_two = Complex::<i8>{real: 0, imaginary: 2};
+        let num_one = Complex::<i8>{ re: 0, im: 9};
+        let num_two = Complex::<i8>{ re: 0, im: 2};
 
-        assert_eq!(num_one.mul(num_two), Complex::<i8>{real: -18, imaginary: 0})
+        assert_eq!(num_one.mul(num_two), Complex::<i8>{ re: -18, im: 0})
     }
 
     #[test]
     fn complex_imaginary_and_real() {
-        let num_one = Complex::<i8>{real: 0, imaginary: -9};
-        let num_two = Complex::<i8>{real: 2, imaginary: 0};
+        let num_one = Complex::<i8>{ re: 0, im: -9};
+        let num_two = Complex::<i8>{ re: 2, im: 0};
 
-        assert_eq!(num_one.mul(num_two), Complex::<i8>{real: 0, imaginary: -18})
+        assert_eq!(num_one.mul(num_two), Complex::<i8>{ re: 0, im: -18})
     }
 
     #[test]
     fn complex_multiply() {
-        let num_one = Complex::<i8>{real: 2, imaginary: 9};
-        let num_two = Complex::<i8>{real: 7, imaginary: 3};
+        let num_one = Complex::<i8>{ re: 2, im: 9};
+        let num_two = Complex::<i8>{ re: 7, im: 3};
 
-        assert_eq!(num_one.mul(num_two), Complex::<i8>{real: -13, imaginary: 69})
+        assert_eq!(num_one.mul(num_two), Complex::<i8>{ re: -13, im: 69})
     }
 
     #[test]
     fn complex_add() {
-        let num_one = Complex::<i8>{real: 2, imaginary: 9};
-        let num_two = Complex::<i8>{real: 7, imaginary: -3};
+        let num_one = Complex::<i8>{ re: 2, im: 9};
+        let num_two = Complex::<i8>{ re: 7, im: -3};
 
-        assert_eq!(num_one.add(num_two), Complex::<i8>{real: 9, imaginary: 6})
+        assert_eq!(num_one.add(num_two), Complex::<i8>{ re: 9, im: 6})
     }
 
     #[test]
     fn complex_sub() {
-        let num_one = Complex::<i8>{real: 2, imaginary: 9};
-        let num_two = Complex::<i8>{real: 7, imaginary: -3};
+        let num_one = Complex::<i8>{ re: 2, im: 9};
+        let num_two = Complex::<i8>{ re: 7, im: -3};
 
-        assert_eq!(num_one.sub(num_two), Complex::<i8>{real: -5, imaginary: 12})
+        assert_eq!(num_one.sub(num_two), Complex::<i8>{ re: -5, im: 12})
     }
 
     #[test]
     fn complex_abs() {
-        let num_one = Complex::<f32>{real: 2f32, imaginary: 9f32};
+        let num_one = Complex::<f32>{ re: 2f32, im: 9f32};
 
         assert_eq!(num_one.abs_square(), 85f32)
     }
 
     #[test]
     fn complex_abs_square_root() {
-        let num_one = Complex::<f32>{real: 2f32, imaginary: 9f32};
+        let num_one = Complex::<f32>{ re: 2f32, im: 9f32};
 
         assert_eq!(num_one.abs(), 85f32.sqrt())
     }
 
     #[test]
     fn scale_a_complex_number_with_f64_rhs() {
-        let num_one = Complex::<f64>{real: 2f64, imaginary: 9f64};
+        let num_one = Complex::<f64>{ re: 2f64, im: 9f64};
 
-        assert_eq!(5f64 * num_one, Complex::<f64>{real: 10f64, imaginary: 45f64})
+        assert_eq!(5f64 * num_one, Complex::<f64>{ re: 10f64, im: 45f64})
     }
 
     #[test]
     fn scale_a_complex_number_with_f64_lhs() {
-        let num_one = Complex::<f64>{real: 2f64, imaginary: 9f64};
+        let num_one = Complex::<f64>{ re: 2f64, im: 9f64};
 
-        assert_eq!(num_one * 5f64, Complex::<f64>{real: 10f64, imaginary: 45f64})
+        assert_eq!(num_one * 5f64, Complex::<f64>{ re: 10f64, im: 45f64})
     }
 }

--- a/src/complex.rs
+++ b/src/complex.rs
@@ -48,7 +48,7 @@ impl Complex<f64> {
     ///
     /// # Example
     /// ```
-    /// use quantr::complex::Complex;
+    /// use quantr::Complex;
     /// use quantr::complex_Im;
     /// use std::f64::consts::PI;
     ///
@@ -67,7 +67,7 @@ impl Complex<f32> {
     ///
     /// # Example
     /// ```
-    /// use quantr::complex::Complex;
+    /// use quantr::Complex;
     /// use quantr::complex_Im;
     /// use std::f32::consts::PI;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ mod error;
 
 pub use circuit::printer::Printer;
 pub use circuit::states;
-pub use circuit::{Circuit, Measurement, Gate};
+pub use circuit::{Circuit, Gate, Measurement};
 pub use complex::{Complex, COMPLEX_ZERO};
 pub use error::QuantrError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,10 @@
 // Make available for public use.
 mod circuit;
 mod complex;
+mod error;
 
 pub use circuit::printer::Printer;
 pub use circuit::states;
 pub use circuit::{Circuit, Measurement, StandardGate};
 pub use complex::Complex;
-
-// For crate use only.
-mod error;
-use error::QuantrError;
+pub use error::QuantrError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
 mod circuit;
 mod complex;
 
-pub use circuit::{Circuit, StandardGate, Measurement};
 pub use circuit::printer::Printer;
 pub use circuit::states;
-pub use complex::Complex; 
+pub use circuit::{Circuit, Measurement, StandardGate};
+pub use complex::Complex;
 
 // For crate use only.
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,15 @@
 
 #![doc = include_str!("../README.md")]
 
-pub mod circuit;
-pub mod complex;
-mod error;
+// Make available for public use.
+mod circuit;
+mod complex;
 
+pub use circuit::{Circuit, StandardGate, Measurement};
+pub use circuit::printer::Printer;
+pub use circuit::states;
+pub use complex::Complex; 
+
+// For crate use only.
+mod error;
 use error::QuantrError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,5 @@ mod error;
 pub use circuit::printer::Printer;
 pub use circuit::states;
 pub use circuit::{Circuit, Measurement, StandardGate};
-pub use complex::Complex;
+pub use complex::{Complex, COMPLEX_ZERO};
 pub use error::QuantrError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,6 @@ mod error;
 
 pub use circuit::printer::Printer;
 pub use circuit::states;
-pub use circuit::{Circuit, Measurement, StandardGate};
+pub use circuit::{Circuit, Measurement, Gate};
 pub use complex::{Complex, COMPLEX_ZERO};
 pub use error::QuantrError;

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -8,13 +8,13 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-use quantr::circuit::{
+use quantr::{
     states::{ProductState, Qubit, SuperPosition},
     Circuit,
     Measurement::{NonObservable, Observable},
     StandardGate,
 };
-use quantr::{complex::Complex, complex_Re};
+use quantr::{Complex, complex_Re};
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
 

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -13,7 +13,7 @@ use quantr::{
     states::{ProductState, Qubit, SuperPosition},
     Circuit,
     Measurement::{NonObservable, Observable},
-    StandardGate,
+    Gate,
 };
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
@@ -23,20 +23,20 @@ fn grovers_3qubit() -> Result<(), QuantrError> {
     let mut circuit = Circuit::new(3)?;
 
     // Kick state into superposition of equal weights
-    circuit.add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
+    circuit.add_repeating_gate(Gate::H, &[0, 1, 2])?;
 
     // Oracle
-    circuit.add_gate(StandardGate::CZ(1), 2)?;
+    circuit.add_gate(Gate::CZ(1), 2)?;
 
     // Amplitude amplification
     circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2])?
-        .add_gate(StandardGate::H, 2)?
-        .add_gate(StandardGate::Toffoli(0, 1), 2)?
-        .add_gate(StandardGate::H, 2)?
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2])?
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
+        .add_repeating_gate(Gate::H, &[0, 1, 2])?
+        .add_repeating_gate(Gate::X, &[0, 1, 2])?
+        .add_gate(Gate::H, 2)?
+        .add_gate(Gate::Toffoli(0, 1), 2)?
+        .add_gate(Gate::H, 2)?
+        .add_repeating_gate(Gate::X, &[0, 1, 2])?
+        .add_repeating_gate(Gate::H, &[0, 1, 2])?;
 
     // Simulates the circuit so that the final register can be
     // calculated.
@@ -76,51 +76,51 @@ const CCCCC_NUMBER: usize = 6;
 fn x3sudoko() -> Result<(), QuantrError> {
     let mut qc: Circuit = Circuit::new(10)?;
 
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?
-        .add_gate(StandardGate::X, 8)?
-        .add_gate(StandardGate::X, 9)?
-        .add_gate(StandardGate::H, 9)?;
+    qc.add_repeating_gate(Gate::H, &[0, 1, 2, 3, 4, 5])?
+        .add_gate(Gate::X, 8)?
+        .add_gate(Gate::X, 9)?
+        .add_gate(Gate::H, 9)?;
 
     // oracle building
     for i in 0..=2 {
-        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8)?;
+        qc.add_gate(Gate::Toffoli(i, i + 3), 8)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
+    qc.add_gate(Gate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
     for i in 0..=2 {
-        qc.add_gate(StandardGate::CNot(i), 6)?;
+        qc.add_gate(Gate::CNot(i), 6)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
+    qc.add_gate(Gate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
     for i in 3..=5 {
-        qc.add_gate(StandardGate::CNot(i), 7)?;
+        qc.add_gate(Gate::CNot(i), 7)?;
     }
 
     // The phase kickback
-    qc.add_gate(StandardGate::Custom(cccnot, &[6, 7, 8], "X".to_string()), 9)?;
+    qc.add_gate(Gate::Custom(cccnot, &[6, 7, 8], "X".to_string()), 9)?;
 
     // Reset by using the oracle again
     for i in 0..=2 {
-        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8)?;
+        qc.add_gate(Gate::Toffoli(i, i + 3), 8)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
+    qc.add_gate(Gate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
     for i in 0..=2 {
-        qc.add_gate(StandardGate::CNot(i), 6)?;
+        qc.add_gate(Gate::CNot(i), 6)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
+    qc.add_gate(Gate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
     for i in 3..=5 {
-        qc.add_gate(StandardGate::CNot(i), 7)?;
+        qc.add_gate(Gate::CNot(i), 7)?;
     }
 
     // Amplitude amplification
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
-        .add_gate(StandardGate::H, 5)?
+    qc.add_repeating_gate(Gate::H, &[0, 1, 2, 3, 4, 5])?
+        .add_repeating_gate(Gate::X, &[0, 1, 2, 3, 4, 5])?
+        .add_gate(Gate::H, 5)?
         .add_gate(
-            StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),
+            Gate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),
             5,
         )?
-        .add_gate(StandardGate::H, 5)?
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?;
+        .add_gate(Gate::H, 5)?
+        .add_repeating_gate(Gate::X, &[0, 1, 2, 3, 4, 5])?
+        .add_repeating_gate(Gate::H, &[0, 1, 2, 3, 4, 5])?;
     // END
 
     qc.simulate();

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -24,30 +24,20 @@ fn grovers_3qubit() {
 
     // Kick state into superposition of equal weights
     circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
-        .unwrap();
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
 
     // Oracle
     circuit.add_gate(StandardGate::CZ(1), 2).unwrap();
 
     // Amplitude amplification
     circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
-        .unwrap();
-    circuit
-        .add_repeating_gate(StandardGate::X, vec![0, 1, 2])
-        .unwrap();
-
-    circuit.add_gate(StandardGate::H, 2).unwrap();
-    circuit.add_gate(StandardGate::Toffoli(0, 1), 2).unwrap();
-    circuit.add_gate(StandardGate::H, 2).unwrap();
-
-    circuit
-        .add_repeating_gate(StandardGate::X, vec![0, 1, 2])
-        .unwrap();
-    circuit
-        .add_repeating_gate(StandardGate::H, vec![0, 1, 2])
-        .unwrap();
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
+        .add_gate(StandardGate::H, 2).unwrap()
+        .add_gate(StandardGate::Toffoli(0, 1), 2).unwrap()
+        .add_gate(StandardGate::H, 2).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
 
     // Simulates the circuit so that the final register can be
     // calculated.
@@ -85,11 +75,10 @@ const CCCCC_NUMBER: usize = 6;
 fn x3sudoko() {
     let mut qc: Circuit = Circuit::new(10).unwrap();
 
-    qc.add_repeating_gate(StandardGate::H, vec![0, 1, 2, 3, 4, 5])
-        .unwrap();
-    qc.add_gate(StandardGate::X, 8).unwrap();
-    qc.add_gate(StandardGate::X, 9).unwrap();
-    qc.add_gate(StandardGate::H, 9).unwrap();
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap()
+        .add_gate(StandardGate::X, 8).unwrap()
+        .add_gate(StandardGate::X, 9).unwrap()
+        .add_gate(StandardGate::H, 9).unwrap();
 
     // oracle building
     for i in 0..=2 {
@@ -126,20 +115,18 @@ fn x3sudoko() {
     }
 
     // Amplitude amplification
-    qc.add_repeating_gate(StandardGate::H, vec![0, 1, 2, 3, 4, 5])
-        .unwrap();
-    qc.add_repeating_gate(StandardGate::X, vec![0, 1, 2, 3, 4, 5])
-        .unwrap();
-    qc.add_gate(StandardGate::H, 5).unwrap();
-    qc.add_gate(
-        StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),
-        5,
-    )
-    .unwrap();
-    qc.add_gate(StandardGate::H, 5).unwrap();
-    qc.add_repeating_gate(StandardGate::X, vec![0, 1, 2, 3, 4, 5])
-        .unwrap();
-    qc.add_repeating_gate(StandardGate::H, vec![0, 1, 2, 3, 4, 5])
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])
+        .unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])
+        .unwrap()
+        .add_gate(StandardGate::H, 5)
+        .unwrap()
+        .add_gate(StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),5,).unwrap()
+        .add_gate(StandardGate::H, 5)
+        .unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])
+        .unwrap()
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])
         .unwrap();
     // END
 

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -11,9 +11,8 @@
 use quantr::{complex_Re, Complex, QuantrError};
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
-    Circuit,
+    Circuit, Gate,
     Measurement::{NonObservable, Observable},
-    Gate,
 };
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
@@ -114,10 +113,7 @@ fn x3sudoko() -> Result<(), QuantrError> {
     qc.add_repeating_gate(Gate::H, &[0, 1, 2, 3, 4, 5])?
         .add_repeating_gate(Gate::X, &[0, 1, 2, 3, 4, 5])?
         .add_gate(Gate::H, 5)?
-        .add_gate(
-            Gate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),
-            5,
-        )?
+        .add_gate(Gate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()), 5)?
         .add_gate(Gate::H, 5)?
         .add_repeating_gate(Gate::X, &[0, 1, 2, 3, 4, 5])?
         .add_repeating_gate(Gate::H, &[0, 1, 2, 3, 4, 5])?;

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -8,7 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-use quantr::{complex_Re, Complex};
+use quantr::{complex_Re, Complex, QuantrError};
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
     Circuit,
@@ -18,27 +18,26 @@ use quantr::{
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
 
-#[rustfmt::skip]
 #[test]
-fn grovers_3qubit() {
-    let mut circuit = Circuit::new(3).unwrap();
+fn grovers_3qubit() -> Result<(), QuantrError>{
+    let mut circuit = Circuit::new(3)?;
 
     // Kick state into superposition of equal weights
     circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
 
     // Oracle
-    circuit.add_gate(StandardGate::CZ(1), 2).unwrap();
+    circuit.add_gate(StandardGate::CZ(1), 2)?;
 
     // Amplitude amplification
     circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
-        .add_gate(StandardGate::H, 2).unwrap()
-        .add_gate(StandardGate::Toffoli(0, 1), 2).unwrap()
-        .add_gate(StandardGate::H, 2).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2]).unwrap()
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2]).unwrap();
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2])?
+        .add_gate(StandardGate::H, 2)?
+        .add_gate(StandardGate::Toffoli(0, 1), 2)?
+        .add_gate(StandardGate::H, 2)?
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2])?
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
 
     // Simulates the circuit so that the final register can be
     // calculated.
@@ -67,63 +66,59 @@ fn grovers_3qubit() {
             }
         }
     }
+
+    Ok(())
 }
 
 const CCC_NUMBER: usize = 4;
 const CCCCC_NUMBER: usize = 6;
 
-#[rustfmt::skip]
 #[test]
-fn x3sudoko() {
-    let mut qc: Circuit = Circuit::new(10).unwrap();
+fn x3sudoko() -> Result<(), QuantrError> {
+    let mut qc: Circuit = Circuit::new(10)?;
 
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap()
-        .add_gate(StandardGate::X, 8).unwrap()
-        .add_gate(StandardGate::X, 9).unwrap()
-        .add_gate(StandardGate::H, 9).unwrap();
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?
+        .add_gate(StandardGate::X, 8)?
+        .add_gate(StandardGate::X, 9)?
+        .add_gate(StandardGate::H, 9)?;
 
     // oracle building
     for i in 0..=2 {
-        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8).unwrap();
+        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)
-        .unwrap();
+    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
     for i in 0..=2 {
-        qc.add_gate(StandardGate::CNot(i), 6).unwrap();
+        qc.add_gate(StandardGate::CNot(i), 6)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)
-        .unwrap();
+    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
     for i in 3..=5 {
-        qc.add_gate(StandardGate::CNot(i), 7).unwrap();
+        qc.add_gate(StandardGate::CNot(i), 7)?;
     }
 
     // The phase kickback
-    qc.add_gate(StandardGate::Custom(cccnot, &[6, 7, 8], "X".to_string()), 9)
-        .unwrap();
+    qc.add_gate(StandardGate::Custom(cccnot, &[6, 7, 8], "X".to_string()), 9)?;
 
     // Reset by using the oracle again
     for i in 0..=2 {
-        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8).unwrap();
+        qc.add_gate(StandardGate::Toffoli(i, i + 3), 8)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)
-        .unwrap();
+    qc.add_gate(StandardGate::Custom(cccnot, &[0, 1, 2], "X".to_string()), 6)?;
     for i in 0..=2 {
-        qc.add_gate(StandardGate::CNot(i), 6).unwrap();
+        qc.add_gate(StandardGate::CNot(i), 6)?;
     }
-    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)
-        .unwrap();
+    qc.add_gate(StandardGate::Custom(cccnot, &[3, 4, 5], "X".to_string()), 7)?;
     for i in 3..=5 {
-        qc.add_gate(StandardGate::CNot(i), 7).unwrap();
+        qc.add_gate(StandardGate::CNot(i), 7)?;
     }
 
     // Amplitude amplification
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5]).unwrap()
-        .add_gate(StandardGate::H, 5).unwrap()
-        .add_gate(StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),5,).unwrap()
-        .add_gate(StandardGate::H, 5).unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5]).unwrap()
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap();
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
+        .add_gate(StandardGate::H, 5)?
+        .add_gate(StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),5,)?
+        .add_gate(StandardGate::H, 5)?
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?;
     // END
 
     qc.simulate();
@@ -138,6 +133,8 @@ fn x3sudoko() {
             }
         }
     }
+
+    Ok(())
 }
 
 fn cccnot(input_state: ProductState) -> SuperPosition {

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -18,6 +18,7 @@ use quantr::{Complex, complex_Re};
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
 
+#[rustfmt::skip]
 #[test]
 fn grovers_3qubit() {
     let mut circuit = Circuit::new(3).unwrap();
@@ -71,6 +72,7 @@ fn grovers_3qubit() {
 const CCC_NUMBER: usize = 4;
 const CCCCC_NUMBER: usize = 6;
 
+#[rustfmt::skip]
 #[test]
 fn x3sudoko() {
     let mut qc: Circuit = Circuit::new(10).unwrap();
@@ -115,19 +117,13 @@ fn x3sudoko() {
     }
 
     // Amplitude amplification
-    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])
-        .unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])
-        .unwrap()
-        .add_gate(StandardGate::H, 5)
-        .unwrap()
+    qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5]).unwrap()
+        .add_gate(StandardGate::H, 5).unwrap()
         .add_gate(StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),5,).unwrap()
-        .add_gate(StandardGate::H, 5)
-        .unwrap()
-        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])
-        .unwrap()
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])
-        .unwrap();
+        .add_gate(StandardGate::H, 5).unwrap()
+        .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5]).unwrap()
+        .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5]).unwrap();
     // END
 
     qc.simulate();

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -8,13 +8,13 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
+use quantr::{complex_Re, Complex};
 use quantr::{
     states::{ProductState, Qubit, SuperPosition},
     Circuit,
     Measurement::{NonObservable, Observable},
     StandardGate,
 };
-use quantr::{Complex, complex_Re};
 use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
 

--- a/tests/grovers.rs
+++ b/tests/grovers.rs
@@ -19,12 +19,11 @@ use std::f64::consts::FRAC_1_SQRT_2;
 const ERROR_MARGIN: f64 = 0.00000001f64;
 
 #[test]
-fn grovers_3qubit() -> Result<(), QuantrError>{
+fn grovers_3qubit() -> Result<(), QuantrError> {
     let mut circuit = Circuit::new(3)?;
 
     // Kick state into superposition of equal weights
-    circuit
-        .add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
+    circuit.add_repeating_gate(StandardGate::H, &[0, 1, 2])?;
 
     // Oracle
     circuit.add_gate(StandardGate::CZ(1), 2)?;
@@ -60,7 +59,7 @@ fn grovers_3qubit() -> Result<(), QuantrError>{
 
     if let Observable(bin_count) = circuit.repeat_measurement(500).unwrap() {
         for (state, count) in bin_count {
-            match state.as_string().as_str() {
+            match state.to_string().as_str() {
                 "011" | "111" => assert!(count > 200usize),
                 _ => assert_eq!(count, 0usize),
             }
@@ -115,7 +114,10 @@ fn x3sudoko() -> Result<(), QuantrError> {
     qc.add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?
         .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
         .add_gate(StandardGate::H, 5)?
-        .add_gate(StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),5,)?
+        .add_gate(
+            StandardGate::Custom(cccccnot, &[0, 1, 2, 3, 4], "X".to_string()),
+            5,
+        )?
         .add_gate(StandardGate::H, 5)?
         .add_repeating_gate(StandardGate::X, &[0, 1, 2, 3, 4, 5])?
         .add_repeating_gate(StandardGate::H, &[0, 1, 2, 3, 4, 5])?;
@@ -125,7 +127,7 @@ fn x3sudoko() -> Result<(), QuantrError> {
 
     if let Observable(bin_count) = qc.repeat_measurement(5000).unwrap() {
         for (state, count) in bin_count {
-            match &state.as_string()[0..=5] {
+            match &state.to_string()[0..=5] {
                 "001100" | "001010" | "010100" | "010001" | "100010" | "100001" => {
                     assert!(count > 150usize)
                 }
@@ -139,47 +141,44 @@ fn x3sudoko() -> Result<(), QuantrError> {
 
 fn cccnot(input_state: ProductState) -> SuperPosition {
     let mut copy_state = input_state.clone();
-    if copy_state.state == [Qubit::One; CCC_NUMBER] {
-        copy_state.state[CCC_NUMBER - 1] = Qubit::Zero;
-        return copy_state.to_super_position();
-    } else if copy_state.state == {
+    if copy_state.qubits == [Qubit::One; CCC_NUMBER] {
+        copy_state.qubits[CCC_NUMBER - 1] = Qubit::Zero;
+        return copy_state.into_super_position();
+    } else if copy_state.qubits == {
         let mut temp = [Qubit::One; CCC_NUMBER];
         temp[CCC_NUMBER - 1] = Qubit::Zero;
         temp
     } {
-        copy_state.state[CCC_NUMBER - 1] = Qubit::One;
-        return copy_state.to_super_position();
+        copy_state.qubits[CCC_NUMBER - 1] = Qubit::One;
+        return copy_state.into_super_position();
     } else {
-        copy_state.to_super_position()
+        copy_state.into_super_position()
     }
 }
 
 // Implementation of a 5 controlled toffoli gate
 fn cccccnot(input_state: ProductState) -> SuperPosition {
     let mut copy_state = input_state.clone();
-    if copy_state.state == [Qubit::One; CCCCC_NUMBER] {
-        copy_state.state[CCCCC_NUMBER - 1] = Qubit::Zero;
-        return copy_state.to_super_position();
-    } else if copy_state.state == {
+    if copy_state.qubits == [Qubit::One; CCCCC_NUMBER] {
+        copy_state.qubits[CCCCC_NUMBER - 1] = Qubit::Zero;
+        return copy_state.into_super_position();
+    } else if copy_state.qubits == {
         let mut temp = [Qubit::One; CCCCC_NUMBER];
         temp[CCCCC_NUMBER - 1] = Qubit::Zero;
         temp
     } {
-        copy_state.state[CCCCC_NUMBER - 1] = Qubit::One;
-        return copy_state.to_super_position();
+        copy_state.qubits[CCCCC_NUMBER - 1] = Qubit::One;
+        return copy_state.into_super_position();
     } else {
-        copy_state.to_super_position()
+        copy_state.into_super_position()
     }
 }
 
 fn compare_complex_lists_and_register(correct_list: &[Complex<f64>], register: &SuperPosition) {
     for (i, &comp_num) in register.amplitudes.iter().enumerate() {
         // Make sure that it turns up complex
-        assert!(equal_within_error(comp_num.real, correct_list[i].real));
-        assert!(equal_within_error(
-            comp_num.imaginary,
-            correct_list[i].imaginary
-        ));
+        assert!(equal_within_error(comp_num.re, correct_list[i].re));
+        assert!(equal_within_error(comp_num.im, correct_list[i].im));
     }
 }
 


### PR DESCRIPTION
I acknowledge that:

- [x] my code passes all tests by running `cargo test`;
- [x] my code is formatted with `cargo fmt`;
- [x] my code successfully compiles the documentation without warnings
  using `cargo doc`;
- [x] I have updated CHANGELOG.md documenting what was changed/added;
- [x] I have added unit testing to test my new code (if applicable);
- [x] I have signed off on all commits with my name and email;
- [x] I have answered all the questions below and given justification
  where appropriate; and
- [x] I am merging with the `dev` branch.

## What is the current problem, or feature that should be added?

_What aspect of the project needs changing?_

A major update was needed to make it more user friendly to the Rust user, such as 

- conforming to naming conventions of `to_` and `into_`;
- making paths shorter and less convoluted when importing structs and enums;
- removing deprecated functions and promoting warnings to errors;
- making `QuantrError` public so that the main function can be adapted to return an option, in turn making code cleaner by not having to use `unwrap()` (see examples/qft.rs for details);
- examples have been added to showcase quantr in action, notably how a QFT gate can be implemented using the custom function;
- Making the gate addition methods return a mutable reference to the circuit, allowing for "functional chaining";
- Replacing vec arguments with slices, as it was unnecessary.

All the above changes, although small in some cases, are breaking. 

Perhaps most noticeably for a quantum circuit simulator, is that the non-exhaustive declaration of the `Gate` enum has been removed. This enum will now declare all of the gates that quantr has out of the box. Of course, custom gates can be declared if a needed gate is missing; however the standard gates that quanta provides are the same as those found in the listing [cQASM instructions](https://www.quantum-inspire.com/kbase/qubits/).

## How does this fix and/or better quantr?

_If it's a feature, please add examples on how you would use it._ 

These changes ultimately make interfacing with quanta less cumbersome and reduces memory requirements on the heap.

## Is this pull request a major or minor change with respect to the `dev` branch?

_Please refer to [semantic versioning for Rust](https://doc.rust-lang.org/cargo/reference/semver.html). If this is a major/breaking change, please add an explanation to why it could not be minor, or equally why it should break the current version._

Major

## What do the unit tests cover?

_Description of the unit tests added (if applicable)._

A unit test was added to show that quantr will catch control nodes that are greater than the size of the circuit, it returns a `QuantrError`.

## Additional comments.

_Any more justifications, examples of output, or even suggestions for improving this pull request template are all welcome!_

The branch was initially made for algorithm optimisations, however, there was more work to be done in the interface of quantr which has lead the naming of this branch to be misleading.