### PR TITLE
Feat optimise algo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file logs the versions of quantr.
 
 ## 0.4.1 - More optimisations
 
+Optimisations:
+
+- The main simulating algorithm has been updated to increase it's speed,
+  mostly bypassing computations that are uneeded:
+  - Product state qubits are flipped only if they are indeed different.
+
 Deprecated features:
 
 - The public fields of `Circuit` are to be made private (specifically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ This file logs the versions of quantr.
 
 ## 0.4.1 - More optimisations
 
+Edited the README to include "No parallelisation" to limitations, and
+reduced the tractable number of qubit simulations to 18.
+
+Change of dependency:
+
+- For the random
+
 Optimisations:
 
 - The main simulating algorithm has been updated to increase it's speed,
-  mostly bypassing computations that are uneeded:
-  - Product state qubits are flipped only if they are indeed different.
+  mostly bypassing computations that are uneeded, for instance product
+  state qubits are flipped only if they are indeed different.
 
 Deprecated features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@ This file logs the versions of quantr.
 ## 0.4.1 - More optimisations
 
 Edited the README to include "No parallelisation" to limitations, and
-reduced the tractable number of qubit simulations to 18.
+reduced the tractable number of qubit simulations to 18. There has also
+been a general clean up of the code, with the help of `cargo clippy`.
 
 Change of dependency:
 
-- For the random
+- The `rand` crate has been swapped with `fastrand` which decreases
+  compilation time.
 
 Optimisations:
 
+- The definition of the gates in `standard_gate_ops.rs` have had there
+  arguments changed so that the `kronecker_prod` is not used; increasing
+  speed for double gate processing.
 - The main simulating algorithm has been updated to increase it's speed,
   mostly bypassing computations that are uneeded, for instance product
   state qubits are flipped only if they are indeed different.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file logs the versions of quantr.
 
+## 0.4.1 - More optimisations
+
+Deprecated features:
+
+- The public fields of `Circuit` are to be made private (specifically
+  updated to `pub(crate)` status in the next breaking update).
+
 ## 0.4.0 - Optimisations of speed and memory allocation
 
 The optimisations and breaking changes that this update induces greatly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quantr"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "EUPL-1.2"
 readme = "README.md"
@@ -13,4 +13,4 @@ description = "Readily create, simulate and print quantum circuits."
 publish = false
 
 [dependencies]
-rand = "0.8.5"
+fastrand = "^2.0.1"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ implementation of Grover's algorithm.
   `1 MiB`.
 - Can simulate circuits up to ~18 qubits within a reasonable time.
 - Only safe Rust code is used, and the only dependency is the
-  [rand](https://docs.rs/rand/latest/rand/) crate and its
+  [fastrand](https://crates.io/crates/fastrand) crate and its
   sub-dependencies.
 
 ### Usage
@@ -97,9 +97,9 @@ guide](QUICK_START.md).
  
 ### Limitations (currently)
 
-- There is **no noise** consideration, or ability to introduce noise.
-- **No parallelisation** available.
-- There is **no ability to add classical wires** nor gates that measure a
+- **No noise** consideration, or ability to introduce noise.
+- **No parallelisation** option.
+- **No ability to add classical wires** nor gates that measure a
   single wire of a quantum circuit.
 
 ### Conventions

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # quantr
 
 [![Crates.io](https://img.shields.io/crates/v/quantr?style=flat-square&color=%23B94700)](https://crates.io/crates/quantr)
-[![Static Badge](https://img.shields.io/badge/version%20-%201.74.1%20-%20white?style=flat-square&logo=rust&color=%23B94700)](https://releases.rs/)
+[![Static Badge](https://img.shields.io/badge/version%20-%201.75.0%20-%20white?style=flat-square&logo=rust&color=%23B94700)](https://releases.rs/)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust.yml?style=flat-square&label=tests&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust.yml)
 [![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/a-barlow/quantr/rust_dev.yml?style=flat-square&label=tests%20(dev)&color=%2349881B)](https://github.com/a-barlow/quantr/actions/workflows/rust_dev.yml)
 [![docs.rs](https://img.shields.io/docsrs/quantr?style=flat-square&color=%2349881B)](https://crates.io/crates/quantr)
@@ -46,7 +46,7 @@ implementation of Grover's algorithm.
   when `n >= 16` is approximately the size of the state vector itself in
   Rust, `2**(n-6) KiB`. For `n < 16`, the memory required is less than
   `1 MiB`.
-- Can simulate circuits up to ~20 qubits within a reasonable time.
+- Can simulate circuits up to ~18 qubits within a reasonable time.
 - Only safe Rust code is used, and the only dependency is the
   [rand](https://docs.rs/rand/latest/rand/) crate and its
   sub-dependencies.
@@ -98,6 +98,7 @@ guide](QUICK_START.md).
 ### Limitations (currently)
 
 - There is **no noise** consideration, or ability to introduce noise.
+- **No parallelisation** available.
 - There is **no ability to add classical wires** nor gates that measure a
   single wire of a quantum circuit.
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -96,7 +96,7 @@ impl<'a> Circuit<'a> {
         self.num_qubits
     }
 
-    /// Returns the vector of gates that have been added to the circuit. 
+    /// Returns the vector of gates that have been added to the circuit.
     ///
     /// It is a flattened vector which is buffered with identity gates.
     ///
@@ -111,7 +111,7 @@ impl<'a> Circuit<'a> {
     /// ```
     pub fn get_gates(&self) -> &[Gate<'a>] {
         self.circuit_gates.as_slice()
-    } 
+    }
 
     /// Adds a single gate to the circuit.
     ///
@@ -288,10 +288,7 @@ impl<'a> Circuit<'a> {
                 // check for overlapping control nodes.
                 if Self::contains_repeating_values(circuit_size, &nodes) {
                     return Err(QuantrError {
-                        message: format!(
-                            "The gate, {:?}, has overlapping control nodes.",
-                            gate
-                        ),
+                        message: format!("The gate, {:?}, has overlapping control nodes.", gate),
                     });
                 }
                 if nodes.contains(&pos) {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -8,6 +8,9 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
+// Added only for silencing deprecated warnings for using public fields of `Circuit`. 
+#![allow(deprecated)]
+
 use super::circuit::gate::{GateInfo, GateSize};
 use crate::states::{ProductState, SuperPosition};
 use crate::{Gate, QuantrError};
@@ -36,7 +39,9 @@ pub enum Measurement<T> {
 /// A quantum circuit where gates can be appended and then simulated to measure resulting
 /// superpositions.
 pub struct Circuit<'a> {
+    #[deprecated(note="This field will be made private to the user, where it will be given pub(crate) status in the next major update.")]
     pub circuit_gates: Vec<Gate<'a>>,
+    #[deprecated(note="This field will be made private to the user, where it will be given pub(crate) status in the next major update.")]
     pub num_qubits: usize,
     output_state: Option<SuperPosition>,
     register: Option<SuperPosition>,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -41,11 +41,11 @@ pub enum Measurement<T> {
 /// superpositions.
 pub struct Circuit<'a> {
     #[deprecated(
-        note = "This field will be made private to the user, where it will be given pub(crate) status in the next major update."
+        note = "This field will be made private to the user, where it will be given pub(crate) status in the next major update. Use Circuit::get_gates instead."
     )]
     pub circuit_gates: Vec<Gate<'a>>,
     #[deprecated(
-        note = "This field will be made private to the user, where it will be given pub(crate) status in the next major update."
+        note = "This field will be made private to the user, where it will be given pub(crate) status in the next major update. Use Circuit::get_num_qubits instead."
     )]
     pub num_qubits: usize,
     output_state: Option<SuperPosition>,
@@ -82,6 +82,36 @@ impl<'a> Circuit<'a> {
             config_progress: false,
         })
     }
+
+    /// Returns the number of qubits in the circuit.
+    ///
+    /// # Example
+    /// ```
+    /// use quantr::{Circuit, Gate};
+    ///
+    /// let quantum_circuit: Circuit = Circuit::new(3).unwrap();
+    /// assert_eq!(quantum_circuit.get_num_qubits(), 3usize);
+    /// ```
+    pub fn get_num_qubits(self) -> usize {
+        self.num_qubits
+    }
+
+    /// Returns the vector of gates that have been added to the circuit. 
+    ///
+    /// It is a flattened vector which is buffered with identity gates.
+    ///
+    /// # Example
+    /// ```
+    /// use quantr::{Circuit, Gate};
+    ///
+    /// let mut quantum_circuit: Circuit = Circuit::new(3).unwrap();
+    /// quantum_circuit.add_gate(Gate::X, 2).unwrap();
+    ///
+    /// assert_eq!(quantum_circuit.get_gates(), &[Gate::Id, Gate::Id, Gate::X]);
+    /// ```
+    pub fn get_gates(&self) -> &[Gate<'a>] {
+        self.circuit_gates.as_slice()
+    } 
 
     /// Adds a single gate to the circuit.
     ///

--- a/src/circuit/printer.rs
+++ b/src/circuit/printer.rs
@@ -260,9 +260,7 @@ impl Printer<'_> {
     }
 
     // Finds if there is a gate with one/multiple control nodes
-    fn get_multi_gate<'a>(
-        gates: &[GatePrinterInfo<'a>],
-    ) -> Option<(usize, GatePrinterInfo<'a>)> {
+    fn get_multi_gate<'a>(gates: &[GatePrinterInfo<'a>]) -> Option<(usize, GatePrinterInfo<'a>)> {
         for (pos, gate_info) in gates.iter().enumerate() {
             match gate_info.gate_size {
                 GateSize::Single => (),

--- a/src/circuit/simulation.rs
+++ b/src/circuit/simulation.rs
@@ -267,10 +267,10 @@ impl<'a> Circuit<'a> {
                 continue;
             }
             // Insert these image states back into a product space
-            let swapped_state: ProductState =
-                prod_state.insert_qubits(state.qubits.as_slice(), gate_positions.as_slice());
-            if mapped_states.contains_key(&swapped_state) {
-                let existing_amp: Complex<f64> = *mapped_states.get(&swapped_state).unwrap();
+            let mut swapped_state: ProductState = prod_state.clone();
+            swapped_state.insert_qubits(state.qubits.as_slice(), gate_positions.as_slice());
+
+            if let Some(existing_amp) = mapped_states.get(&swapped_state) {
                 mapped_states.insert(swapped_state, existing_amp.add(state_amp.mul(amp)));
             } else {
                 mapped_states.insert(swapped_state, state_amp.mul(amp));

--- a/src/circuit/simulation.rs
+++ b/src/circuit/simulation.rs
@@ -80,7 +80,7 @@ impl<'a> Circuit<'a> {
         // the sum of states that are required to be added to the register
         let mut mapped_states: HashMap<ProductState, Complex<f64>> = Default::default();
 
-        for (prod_state, amp) in (&register).into_iter() {
+        for (prod_state, amp) in register.into_iter() {
             //Looping through super position of register
 
             // Obtain superposition from applying gate from a specified wire onto the product state, and add control nodes if necersary

--- a/src/circuit/simulation.rs
+++ b/src/circuit/simulation.rs
@@ -160,17 +160,15 @@ impl<'a> Circuit<'a> {
         if let Gate::CR(angle, control) = double_gate.name {
             positions.push(control);
             standard_gate_ops::cr(
-                prod_state
-                    .get_unchecked(control)
-                    .kronecker_prod(prod_state.get_unchecked(double_gate.position)),
+                prod_state.get_unchecked(control),
+                prod_state.get_unchecked(double_gate.position),
                 angle,
             )
         } else if let Gate::CRk(k, control) = double_gate.name {
             positions.push(control);
             standard_gate_ops::crk(
-                prod_state
-                    .get_unchecked(control)
-                    .kronecker_prod(prod_state.get_unchecked(double_gate.position)),
+                prod_state.get_unchecked(control),
+                prod_state.get_unchecked(double_gate.position),
                 k,
             )
         } else {
@@ -197,9 +195,8 @@ impl<'a> Circuit<'a> {
 
             positions.push(control_node);
             operator(
-                prod_state
-                    .get_unchecked(control_node)
-                    .kronecker_prod(prod_state.get_unchecked(double_gate.position)),
+                prod_state.get_unchecked(control_node),
+                prod_state.get_unchecked(double_gate.position),
             )
         }
     }
@@ -218,10 +215,9 @@ impl<'a> Circuit<'a> {
         positions.push(control_node_two);
         positions.push(control_node_one);
         operator(
-            prod_state
-                .get_unchecked(control_node_one)
-                .kronecker_prod(prod_state.get_unchecked(control_node_two))
-                .kronecker_prod(prod_state.get_unchecked(triple_gate.position)),
+            prod_state.get_unchecked(control_node_one),
+            prod_state.get_unchecked(control_node_two),
+            prod_state.get_unchecked(triple_gate.position),
         )
     }
 

--- a/src/circuit/standard_gate_ops.rs
+++ b/src/circuit/standard_gate_ops.rs
@@ -13,7 +13,7 @@
 //! These linear functions are defined by how they act on product states of qubits. Defining the
 //! mappings on a basis defines how the gates act on larger product spaces.
 
-use crate::states::{ProductState, Qubit, SuperPosition};
+use crate::states::{Qubit, SuperPosition};
 use crate::Complex;
 use crate::{complex, complex_im, complex_im_array, complex_re, complex_re_array, COMPLEX_ZERO};
 use std::f64::consts::FRAC_1_SQRT_2;
@@ -194,9 +194,8 @@ pub fn pauli_z(register: Qubit) -> SuperPosition {
 //
 
 #[rustfmt::skip]
-pub fn cnot(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+pub fn cnot(qubit_one: Qubit, qubit_two: Qubit) -> SuperPosition {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_re_array!(0f64, 0f64, 0f64, 1f64),
@@ -205,9 +204,8 @@ pub fn cnot(register: ProductState) -> SuperPosition {
 }
 
 #[rustfmt::skip]
-pub fn cy(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+pub fn cy(qubit_one: Qubit, qubit_two: Qubit) -> SuperPosition {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_im_array!(0f64, 0f64, 0f64, 1f64),
@@ -216,9 +214,8 @@ pub fn cy(register: ProductState) -> SuperPosition {
 }
 
 #[rustfmt::skip]
-pub fn cz(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+pub fn cz(qubit_one: Qubit, qubit_two: Qubit) -> SuperPosition {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_re_array!(0f64, 0f64, 1f64, 0f64),
@@ -227,9 +224,8 @@ pub fn cz(register: ProductState) -> SuperPosition {
 }
 
 #[rustfmt::skip]
-pub fn swap(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+pub fn swap(qubit_one: Qubit, qubit_two: Qubit) -> SuperPosition {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 0f64, 1f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
@@ -238,10 +234,9 @@ pub fn swap(register: ProductState) -> SuperPosition {
 }
 
 #[rustfmt::skip]
-pub fn cr(register: ProductState, angle: f64) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
+pub fn cr(qubit_one: Qubit, qubit_two: Qubit, angle: f64) -> SuperPosition {
     let exp_array: [Complex<f64>; 4] = [COMPLEX_ZERO, COMPLEX_ZERO, COMPLEX_ZERO, Complex::<f64>::exp_im(angle)];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_re_array!(0f64, 0f64, 1f64, 0f64),
@@ -250,11 +245,10 @@ pub fn cr(register: ProductState, angle: f64) -> SuperPosition {
 }
 
 #[rustfmt::skip]
-pub fn crk(register: ProductState, k: i32) -> SuperPosition {
-    let input_register: [Qubit; 2] = [register.qubits[0], register.qubits[1]];
+pub fn crk(qubit_one: Qubit, qubit_two: Qubit, k: i32) -> SuperPosition {
     let exp_array: [Complex<f64>; 4] = 
         [COMPLEX_ZERO, COMPLEX_ZERO, COMPLEX_ZERO, Complex::<f64>::exp_im((2f64*std::f64::consts::PI).div(2f64.powi(k)))];
-    SuperPosition::new_with_register_unchecked::<4>(match input_register {
+    SuperPosition::new_with_register_unchecked::<4>(match [qubit_one, qubit_two] {
         [Qubit::Zero, Qubit::Zero] => complex_re_array!(1f64, 0f64, 0f64, 0f64),
         [Qubit::Zero, Qubit::One]  => complex_re_array!(0f64, 1f64, 0f64, 0f64),
         [Qubit::One, Qubit::Zero]  => complex_re_array!(0f64, 0f64, 1f64, 0f64),
@@ -267,9 +261,8 @@ pub fn crk(register: ProductState, k: i32) -> SuperPosition {
 //
 
 #[rustfmt::skip]
-pub fn toffoli(register: ProductState) -> SuperPosition {
-    let input_register: [Qubit; 3] = [register.qubits[0], register.qubits[1], register.qubits[2]];
-    SuperPosition::new_with_register_unchecked::<8>(match input_register {
+pub fn toffoli(qubit_one: Qubit, qubit_two: Qubit, qubit_three: Qubit) -> SuperPosition {
+    SuperPosition::new_with_register_unchecked::<8>(match [qubit_one, qubit_two, qubit_three] {
             [Qubit::Zero, Qubit::Zero, Qubit::Zero] => { complex_re_array!(1f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64) }
             [Qubit::Zero, Qubit::Zero, Qubit::One] => { complex_re_array!(0f64, 1f64, 0f64, 0f64, 0f64, 0f64, 0f64, 0f64) }
             [Qubit::Zero, Qubit::One, Qubit::Zero] => { complex_re_array!(0f64, 0f64, 1f64, 0f64, 0f64, 0f64, 0f64, 0f64) }

--- a/src/circuit/states/product_states.rs
+++ b/src/circuit/states/product_states.rs
@@ -106,18 +106,18 @@ impl ProductState {
 
     // Changes the qubits at specified positions within the product state with a slice of other
     // qubits.
-    pub(crate) fn insert_qubits(&self, qubits: &[Qubit], pos: &[usize]) -> ProductState {
-        let mut edited_qubits: Vec<Qubit> = self.qubits.clone();
-        let num_qubits: usize = qubits.len();
+    pub(crate) fn insert_qubits(&mut self, qubits: &[Qubit], pos: &[usize]) {
+        //let mut edited_qubits: Vec<Qubit> = self.qubits.clone();
 
-        if num_qubits != pos.len() {
-            panic!("Size of qubits and positions must be equal.")
+        for (enum_i, &i) in pos.iter().enumerate() {
+            if self.qubits[i] != qubits[enum_i] {
+                self.qubits[i] = match self.qubits[i] {
+                    Qubit::Zero => Qubit::One,
+                    Qubit::One => Qubit::Zero,
+                };
+            }
         }
 
-        for (index, position) in pos.iter().enumerate() {
-            edited_qubits[*position] = qubits[index];
-        }
-        ProductState::new_unchecked(&edited_qubits)
     }
 
     /// Returns the number of qubits that form the product state.
@@ -274,11 +274,11 @@ mod tests {
 
     #[test]
     fn insert_qubits_in_state() {
+        let mut prod = ProductState::new_unchecked(&[Qubit::One, Qubit::One, Qubit::One]); 
+        prod.insert_qubits(&[Qubit::Zero, Qubit::Zero], &[0, 2]);
         assert_eq!(
-            ProductState::new_unchecked(&[Qubit::Zero, Qubit::Zero, Qubit::One]).qubits,
-            ProductState::new_unchecked(&[Qubit::One, Qubit::One, Qubit::One])
-                .insert_qubits(&[Qubit::Zero, Qubit::Zero], &[0, 1])
-                .qubits
+            ProductState::new_unchecked(&[Qubit::Zero, Qubit::One, Qubit::Zero]).qubits,
+            prod.qubits 
         );
     }
 

--- a/src/circuit/states/product_states.rs
+++ b/src/circuit/states/product_states.rs
@@ -154,7 +154,7 @@ impl ProductState {
             return Err(QuantrError { message: format!("The position of the binary digit, {}, is out of bounds. The product dimension is {}, and so the position must be strictly less.", place_num, self.num_qubits()) });
         }
 
-        let old_qubit: Qubit = self.qubits[place_num].clone();
+        let old_qubit: Qubit = self.qubits[place_num];
         self.qubits[place_num] = if old_qubit == Qubit::Zero {
             Qubit::One
         } else {
@@ -195,6 +195,7 @@ impl ProductState {
     ///
     /// assert_eq!(String::from("01"), prod.to_string());
     /// ```
+    #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         self.qubits
             .iter()
@@ -215,7 +216,7 @@ impl ProductState {
                 Qubit::Zero => 0u32,
                 Qubit::One => 1 << pos,
             })
-            .fold(0, |sum, i| sum + i) as usize
+            .sum::<u32>() as usize
     }
 
     // Produces a product states based on converting a base 10 number to binary, where the product

--- a/src/circuit/states/product_states.rs
+++ b/src/circuit/states/product_states.rs
@@ -8,6 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
+use crate::circuit::QResult;
 use crate::states::Qubit;
 use crate::QuantrError;
 
@@ -31,7 +32,7 @@ impl ProductState {
     ///
     /// let prod: ProductState = ProductState::new(&[Qubit::One, Qubit::Zero]).unwrap(); // |10>
     /// ```
-    pub fn new(product_state: &[Qubit]) -> Result<ProductState, QuantrError> {
+    pub fn new(product_state: &[Qubit]) -> QResult<ProductState> {
         if product_state.is_empty() {
             return Err(QuantrError {
                 message: String::from(
@@ -117,7 +118,6 @@ impl ProductState {
                 };
             }
         }
-
     }
 
     /// Returns the number of qubits that form the product state.
@@ -149,7 +149,7 @@ impl ProductState {
     ///
     /// assert_eq!(&[Qubit::One, Qubit::One, Qubit::One], prod.get_qubits());
     /// ```
-    pub fn invert_digit(&mut self, place_num: usize) -> Result<&mut ProductState, QuantrError> {
+    pub fn invert_digit(&mut self, place_num: usize) -> QResult<&mut ProductState> {
         if place_num >= self.num_qubits() {
             return Err(QuantrError { message: format!("The position of the binary digit, {}, is out of bounds. The product dimension is {}, and so the position must be strictly less.", place_num, self.num_qubits()) });
         }
@@ -274,11 +274,11 @@ mod tests {
 
     #[test]
     fn insert_qubits_in_state() {
-        let mut prod = ProductState::new_unchecked(&[Qubit::One, Qubit::One, Qubit::One]); 
+        let mut prod = ProductState::new_unchecked(&[Qubit::One, Qubit::One, Qubit::One]);
         prod.insert_qubits(&[Qubit::Zero, Qubit::Zero], &[0, 2]);
         assert_eq!(
             ProductState::new_unchecked(&[Qubit::Zero, Qubit::One, Qubit::Zero]).qubits,
-            prod.qubits 
+            prod.qubits
         );
     }
 

--- a/src/circuit/states/super_positions.rs
+++ b/src/circuit/states/super_positions.rs
@@ -8,7 +8,7 @@
 * Author: Andrew Rowan Barlow <a.barlow.dev@gmail.com>
 */
 
-use crate::circuit::{HashMap, ZERO_MARGIN};
+use crate::circuit::{HashMap, QResult, ZERO_MARGIN};
 use crate::complex_re;
 use crate::{states::ProductState, Complex, QuantrError, COMPLEX_ZERO};
 
@@ -33,7 +33,7 @@ impl SuperPosition {
     ///
     /// assert_eq!(&complex_re_array![1f64, 0f64, 0f64, 0f64], superpos.get_amplitudes());
     /// ```
-    pub fn new(prod_dimension: usize) -> Result<SuperPosition, QuantrError> {
+    pub fn new(prod_dimension: usize) -> QResult<SuperPosition> {
         if prod_dimension == 0 {
             return Err(QuantrError {
                 message: String::from("The number of qubits must be non-zero."),
@@ -60,7 +60,7 @@ impl SuperPosition {
     ///
     /// assert_eq!(&complex_re_array![1f64, 0f64, 0f64, 0f64], superpos.get_amplitudes());
     /// ```
-    pub fn new_with_amplitudes(amplitudes: &[Complex<f64>]) -> Result<SuperPosition, QuantrError> {
+    pub fn new_with_amplitudes(amplitudes: &[Complex<f64>]) -> QResult<SuperPosition> {
         if !Self::equal_within_error(amplitudes.iter().map(|x| x.abs_square()).sum::<f64>(), 1f64) {
             return Err(QuantrError {
                 message: String::from("Slice given to set amplitudes in super position does not conserve probability, the absolute square sum of the coefficents must be one."),
@@ -100,7 +100,7 @@ impl SuperPosition {
     /// ```
     pub fn new_with_hash_amplitudes(
         hash_amplitudes: HashMap<ProductState, Complex<f64>>,
-    ) -> Result<SuperPosition, QuantrError> {
+    ) -> QResult<SuperPosition> {
         if hash_amplitudes.is_empty() {
             return Err(QuantrError { message: String::from("An empty HashMap was given. A superposition must have at least one non-zero state.") });
         }
@@ -137,7 +137,7 @@ impl SuperPosition {
     ///
     /// assert_eq!(complex_re!(1f64), superpos.get_amplitude(1).unwrap());
     /// ```
-    pub fn get_amplitude(&self, pos: usize) -> Result<Complex<f64>, QuantrError> {
+    pub fn get_amplitude(&self, pos: usize) -> QResult<Complex<f64>> {
         if pos >= self.amplitudes.len() {
             let length = self.amplitudes.len();
             Err(QuantrError { message: format!("Failed to retrieve amplitude from list. Index given was, {pos}, which is greater than length of list, {length}."), 
@@ -205,10 +205,7 @@ impl SuperPosition {
     ///
     /// assert_eq!(complex_re!(1f64), superpos.get_amplitude_from_state(prod_state).unwrap());
     /// ```
-    pub fn get_amplitude_from_state(
-        &self,
-        prod_state: ProductState,
-    ) -> Result<Complex<f64>, QuantrError> {
+    pub fn get_amplitude_from_state(&self, prod_state: ProductState) -> QResult<Complex<f64>> {
         if 2usize << prod_state.qubits.len() - 1 != self.amplitudes.len() {
             return Err(QuantrError { message: format!("Unable to retreive product state, |{:?}> with dimension {}. The superposition is a linear combination of states with different dimension. These dimensions should be equal.", prod_state.to_string(), prod_state.num_qubits()),});
         }
@@ -230,10 +227,7 @@ impl SuperPosition {
     ///
     /// assert_eq!(&complex_re_array![0f64, 1f64, 0f64, 0f64], superpos.get_amplitudes());
     /// ```
-    pub fn set_amplitudes(
-        &mut self,
-        amplitudes: &[Complex<f64>],
-    ) -> Result<&mut SuperPosition, QuantrError> {
+    pub fn set_amplitudes(&mut self, amplitudes: &[Complex<f64>]) -> QResult<&mut SuperPosition> {
         if amplitudes.len() != self.amplitudes.len() {
             return Err(QuantrError {
                 message: format!("The slice given to set the amplitudes in the computational basis has length {}, when it should have length {}.", amplitudes.len(), self.amplitudes.len()),
@@ -278,7 +272,7 @@ impl SuperPosition {
     pub fn set_amplitudes_from_states(
         &mut self,
         amplitudes: HashMap<ProductState, Complex<f64>>,
-    ) -> Result<&mut SuperPosition, QuantrError> {
+    ) -> QResult<&mut SuperPosition> {
         // Check if amplitudes and product states are correct.
         if amplitudes.is_empty() {
             return Err(QuantrError { message: String::from("An empty HashMap was given. A superposition must have at least one non-zero state.") });

--- a/src/circuit/states/super_positions.rs
+++ b/src/circuit/states/super_positions.rs
@@ -206,7 +206,7 @@ impl SuperPosition {
     /// assert_eq!(complex_re!(1f64), superpos.get_amplitude_from_state(prod_state).unwrap());
     /// ```
     pub fn get_amplitude_from_state(&self, prod_state: ProductState) -> QResult<Complex<f64>> {
-        if 2usize << prod_state.qubits.len() - 1 != self.amplitudes.len() {
+        if 2usize << (prod_state.qubits.len() - 1) != self.amplitudes.len() {
             return Err(QuantrError { message: format!("Unable to retreive product state, |{:?}> with dimension {}. The superposition is a linear combination of states with different dimension. These dimensions should be equal.", prod_state.to_string(), prod_state.num_qubits()),});
         }
         Ok(*self.amplitudes.get(prod_state.comp_basis()).unwrap())
@@ -329,11 +329,11 @@ impl SuperPosition {
     ) {
         let length: usize = vec_amplitudes.len();
         let trailing_length: usize = length.trailing_zeros() as usize;
-        for i in 0..length {
+        for (i, amp) in vec_amplitudes.iter_mut().enumerate() {
             let key: ProductState = ProductState::binary_basis(i, trailing_length);
             match hash_amplitudes.get(&key) {
-                Some(val) => vec_amplitudes[i] = *val,
-                None => vec_amplitudes[i] = COMPLEX_ZERO,
+                Some(val) => *amp = *val,
+                None => *amp = COMPLEX_ZERO,
             }
         }
     }

--- a/src/circuit/states/super_positions_unchecked.rs
+++ b/src/circuit/states/super_positions_unchecked.rs
@@ -41,9 +41,9 @@ impl SuperPosition {
     /// States that are missing from the HashMap will be assumed to have 0 amplitude.
     pub(crate) fn set_amplitudes_from_states_unchecked(
         &mut self,
-        amplitudes: HashMap<ProductState, Complex<f64>>,
+        hash_amplitudes: HashMap<ProductState, Complex<f64>>,
     ) -> &mut SuperPosition {
-        for (key, val) in amplitudes {
+        for (key, val) in hash_amplitudes {
             self.amplitudes[key.comp_basis()] = val;
         }
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,39 +34,35 @@
 //! ```
 //! use quantr::{Circuit, Gate, Printer, Measurement::Observable};
 //!
-//! fn main() {
+//! let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
+//! 
+//! quantum_circuit
+//!     .add_gates(&[Gate::H, Gate::Y]).unwrap()
+//!     .add_gate(Gate::CNot(0), 1).unwrap();
+//! 
+//! let mut printer = Printer::new(&quantum_circuit);
+//! printer.print_diagram();
+//! // The above prints the following:
+//! // ┏━━━┓     
+//! // ┨ H ┠──█──
+//! // ┗━━━┛  │  
+//! //        │  
+//! // ┏━━━┓┏━┷━┓
+//! // ┨ Y ┠┨ X ┠
+//! // ┗━━━┛┗━━━┛
 //!
-//!    let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
-//!     
-//!     quantum_circuit
-//!         .add_gates(&[Gate::H, Gate::Y]).unwrap()
-//!         .add_gate(Gate::CNot(0), 1).unwrap();
-//!     
-//!     let mut printer = Printer::new(&quantum_circuit);
-//!     printer.print_diagram();
-//!     // The above prints the following:
-//!     // ┏━━━┓     
-//!     // ┨ H ┠──█──
-//!     // ┗━━━┛  │  
-//!     //        │  
-//!     // ┏━━━┓┏━┷━┓
-//!     // ┨ Y ┠┨ X ┠
-//!     // ┗━━━┛┗━━━┛
+//! quantum_circuit.simulate();
 //!
-//!    quantum_circuit.simulate();
+//! // Below prints the number of times that each state was observered
+//! // over 500 measurements of superpositions.
 //!
-//!    // Below prints the number of times that each state was observered
-//!     // over 500 measurements of superpositions.
-//!
-//!    if let Ok(Observable(bin_count)) = quantum_circuit.repeat_measurement(500) {
-//!         println!("[Observable] Bin count of observed states.");
-//!         for (state, count) in bin_count {
-//!             println!("|{}> observed {} times", state.to_string(), count);
-//!         }
+//! if let Ok(Observable(bin_count)) = quantum_circuit.repeat_measurement(500) {
+//!     println!("[Observable] Bin count of observed states.");
+//!     for (state, count) in bin_count {
+//!         println!("|{}> observed {} times", state.to_string(), count);
 //!     }
-//!
 //! }
-//! ```
+//!
 
 mod circuit;
 mod complex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,11 @@
 //! use quantr::{Circuit, Gate, Printer, Measurement::Observable};
 //!
 //! let mut quantum_circuit: Circuit = Circuit::new(2).unwrap();
-//! 
+//!
 //! quantum_circuit
 //!     .add_gates(&[Gate::H, Gate::Y]).unwrap()
 //!     .add_gate(Gate::CNot(0), 1).unwrap();
-//! 
+//!
 //! let mut printer = Printer::new(&quantum_circuit);
 //! printer.print_diagram();
 //! // The above prints the following:


### PR DESCRIPTION
I acknowledge that:

- [x] my code passes all tests by running `cargo test`;
- [x] my code is formatted with `cargo fmt`;
- [x] my code successfully compiles the documentation without warnings
  using `cargo doc`;
- [x] I have updated CHANGELOG.md documenting what was changed/added;
- [x] I have added unit testing to test my new code (if applicable);
- [x] I have signed off on all commits with my name and email;
- [x] I have answered all the questions below and given justification
  where appropriate; and
- [x] I am merging with the `dev` branch.

## What is the current problem, or feature that should be added?

_What aspect of the project needs changing?_

1. The tractable number of qubits was misleading, and the code requires a lot of cleanup, as suggested by `cargo clippy`.

2. Some fields of `Circuit` are still public, which allows the user to edit them, potentially destroying assumptions needed for simulation. 

## How does this fix and/or better quantr?

_If it's a feature, please add examples on how you would use it._ 

1. The number has been reduced to 18, and suggestions from `cargo clippy` have been implemented.

2. These have been marked deprecated for now, and methods have been added so that the user can access these fields, but not modify them.

## Is this pull request a major or minor change with respect to the `dev` branch?

_Please refer to [semantic versioning for Rust](https://doc.rust-lang.org/cargo/reference/semver.html). If this is a major/breaking change, please add an explanation to why it could not be minor, or equally why it should break the current version._

Minor

## What do the unit tests cover?

_Description of the unit tests added (if applicable)._

Not applicable.

## Additional comments.

_Any more justifications, examples of output, or even suggestions for improving this pull request template are all welcome!_

More work is needed for accurately analysing the performance of quantr, in terms of memory usage and speed. For example, generating random circuits to bench, instead of only grovers.